### PR TITLE
fix(enedis): omission of empty value check in parser

### DIFF
--- a/scripts/enedisParser.js
+++ b/scripts/enedisParser.js
@@ -20,6 +20,10 @@ var enedisParser = {
             if (row.length > 1) {
                 const date = new Date(row[0].replace("+01:00", "+00:00"));
                 const value = row[1];
+                // Si la valeur est vide, on ne l'ajoute pas
+                if (value === "") {
+                    return;
+                }
 
                 //la date dans le CSV est la fin de la tranche 
                 //(Exemple : 06:00:00 correspond à 5h30 > 6h00)


### PR DESCRIPTION
Bonjour,

Dans mon export Enedis, j'ai des jours/heures sans valeur. Cela amène à des NaN à plusieurs endroits.

<img width="296" alt="Capture d’écran 2024-01-19 à 13 15 18" src="https://github.com/JC144/EDF_Simulateur_Prix/assets/15020891/67c36078-404c-4107-a434-c8073dd4414a">
<img width="572" alt="Capture d’écran 2024-01-19 à 13 15 25" src="https://github.com/JC144/EDF_Simulateur_Prix/assets/15020891/bd8efdb7-7036-453d-94eb-638a76239605">

J'ai fixé en ignorant les lignes vides.