### PR TITLE
Correction calcul couleur Tempo

### DIFF
--- a/scripts/calculator.js
+++ b/scripts/calculator.js
@@ -37,27 +37,28 @@ var calculator = {
                 dayData.consoHP = 0;
                 dayData.priceHP = 0;
 
-                dayData.dayType = grille.getDayType(dayData, jourZenPlus);
-
                 for (let hour = 0; hour < data[day].hours.length - 1; hour += 2) {
+
                     let hourData = {};
 
-                    hourData.hour = data[day].hours[hour][0].split(":")[0] + ":00:00";
+                    let hourPart = data[day].hours[hour][0].split(":")[0];
+                    hourData.hour = hourPart + ":00:00";
                     hourData.conso = (parseInt(data[day].hours[hour][1]) + parseInt(data[day].hours[hour + 1][1])) / 2;
 
-                    let currentHour = parseInt(data[day].hours[hour][0].split(":")[0]);
+                    let currentHour = parseInt(hourPart);
+                    const dayType = grille.getDayType(dayData, jourZenPlus, currentHour);
 
                     if (grille.hc.some(range => currentHour >= range.start && currentHour < range.end)) {
-                        let prixKwhHC = abonnement[dayData.dayType].prixKwhHC;
+                        let prixKwhHC = abonnement[dayType].prixKwhHC;
 
-                        hourData.type = dayData.dayType + " HC";
+                        hourData.type = dayType + " HC";
                         hourData.price = (((hourData.conso / 1000) * prixKwhHC) / 100);
                         dayData.consoHC += hourData.conso;
                         dayData.priceHC += hourData.price;
                     }
                     else {
-                        let prixKwhHP = abonnement[dayData.dayType].prixKwhHP;
-                        hourData.type = dayData.dayType + " HP";
+                        let prixKwhHP = abonnement[dayType].prixKwhHP;
+                        hourData.type = dayType + " HP";
 
                         hourData.price = (((hourData.conso / 1000) * prixKwhHP) / 100);
                         dayData.consoHP += hourData.conso;

--- a/scripts/tarifs/edf/tempo.js
+++ b/scripts/tarifs/edf/tempo.js
@@ -393,11 +393,19 @@ abonnements.push({
             "2024/01/17"
         ]
     }],
-    getDayType: function (day) {
+    getDayType: function (day, _, hour) {
         let dayType = "bleu";
+        let date = day.date;
+
+        if (hour < 6) {
+            // color is that of previous day
+            let dateObj = new Date(day.date + " 12:00:00"); // JS doesn't have proper parsing routines
+            dateObj.setDate(dateObj.getDate() - 1);
+            date = dateObj.toISOString().split("T")[0].replace(/-/g, "/");
+        }
 
         this.specialDays.forEach((specialDay) => {
-            if (specialDay.lastDays.includes(day.date)) {
+            if (specialDay.lastDays.includes(date)) {
                 dayType = specialDay.name;
             }
         });


### PR DESCRIPTION
Sur Tempo, les jours commencent et finissent à 6h et pas à minuit, en conséquence, si le jour A est bleu et le jour A+1 est rouge, alors le tarif est :
- bleu le jour A de 6h à 23h59
- bleu le jour A+1 de 0h à 5h59
- rouge le jour A+1 de 6h à 23h59
- rouge le jour A+2 de 0h à 5h59

J'ai rencontré le même bug sur mon outil (https://github.com/zdimension/elecanalysis), ça provoque une (légère) différence de tarifs avec la réalité. 

PS: je me demandais, pourquoi ne pas inclure l'abonnement au prorata journalier dans les résultats détaillés ?