### PR TITLE
Calcul prorata d'abonnement et fix au parsing Enedis

### DIFF
--- a/scripts/calculator.js
+++ b/scripts/calculator.js
@@ -8,6 +8,8 @@ var calculator = {
             let currentMonth = 0;
             let currentYear = 0;
 
+            let prixAbo = 0;
+
             let monthData = {};
             for (let day = 0; day < data.length; day++) {
                 let date = data[day].date.split("/");
@@ -16,14 +18,16 @@ var calculator = {
                 if (date[1] != currentMonth) {
                     if (monthData.days) {
                         monthData.conso = monthData.days.filter(d => !isNaN(d.conso)).reduce((a, b) => a + b.conso, 0);
-                        monthData.price = monthData.days.filter(d => !isNaN(d.price)).reduce((a, b) => a + b.price, 0) + abonnement.abonnement;
+                        monthData.price = monthData.days.filter(d => !isNaN(d.price)).reduce((a, b) => a + b.price, 0);
                     }
                     currentMonth = date[1];
                     monthData = {};
                     monthData.month = currentMonth;
                     monthData.year = currentYear;
-                    monthData.firstDayDate = new Date(currentYear, currentMonth, 1);
+                    monthData.firstDayDate = new Date(currentYear, +currentMonth - 1, 1);
                     monthData.days = [];
+
+                    prixAbo = abonnement.abonnement / new Date(currentYear, +currentMonth, 0).getDate();
 
                     monthsData.push(monthData);
                 }
@@ -68,11 +72,11 @@ var calculator = {
                 }
 
                 dayData.conso = dayData.hours.reduce((a, b) => a + b.conso, 0);
-                dayData.price = dayData.hours.reduce((a, b) => a + b.price, 0);
+                dayData.price = dayData.hours.reduce((a, b) => a + b.price, 0) + prixAbo;
                 monthData.days.push(dayData);
             }
             monthData.conso = monthData.days.filter(d => !isNaN(d.conso)).reduce((a, b) => a + b.conso, 0);
-            monthData.price = monthData.days.filter(d => !isNaN(d.price)).reduce((a, b) => a + b.price, 0) + abonnement.abonnement;
+            monthData.price = monthData.days.filter(d => !isNaN(d.price)).reduce((a, b) => a + b.price, 0);
         }
 
         return monthsData;

--- a/scripts/enedisParser.js
+++ b/scripts/enedisParser.js
@@ -18,7 +18,7 @@ var enedisParser = {
 
         rows.reverse().forEach(row => {
             if (row.length > 1) {
-                const date = new Date(row[0].replace("+01:00", "+00:00"));
+                const date = new Date(row[0].replace(/\+0.:00/g, "+00:00"));
                 const value = row[1];
 
                 //la date dans le CSV est la fin de la tranche 


### PR DESCRIPTION
Ça parsait mal les heures d'été depuis un CSV Enedis. Il reste quand même un problème pour le calcul des données pile au niveau du changement d'heure, puisque les dates font :
```
2023-10-29T01:00:00+02:00
2023-10-29T01:30:00+02:00
2023-10-29T02:00:00+02:00
2023-10-29T02:30:00+02:00
2023-10-29T02:00:00+01:00
2023-10-29T02:30:00+01:00
2023-10-29T03:00:00+01:00
2023-10-29T03:30:00+01:00
```
L'erreur n'est que de quelques centimes, mais bon.