### PR TITLE
[FIX] calcul des HC / HP pour EDF

### DIFF
--- a/scripts/calculator.js
+++ b/scripts/calculator.js
@@ -140,11 +140,7 @@ function getShiftedHour(hourLine, shiftTime) {
 
     let shiftedTime = new Date(time - shift * 60000);
 
-    shiftedTime = shiftedTime.getHours().toString() + ":" +
-           shiftedTime.getMinutes().toString() + ":" +
-           shiftedTime.getSeconds().toString();
-
-    return parseInt(shiftedTime);
+    return parseInt(shiftedTime.getHours());
 }
 
 function getHourData(dayData, hourKey) {

--- a/scripts/tarifs/edf/bleu.js
+++ b/scripts/tarifs/edf/bleu.js
@@ -2,6 +2,7 @@ abonnements.push(
     {
         name: "EDF - Bleu",
         lastUpdate: "2023-08-01",
+        shiftTime: 30,        
         prices: [{
             puissance: 3,
             abonnement: 9.47,

--- a/scripts/tarifs/edf/bleuHC.js
+++ b/scripts/tarifs/edf/bleuHC.js
@@ -1,6 +1,7 @@
 abonnements.push({
     name: "EDF - Bleu Heures Creuses",
     lastUpdate: "2023-08-01",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 6,

--- a/scripts/tarifs/edf/ejp.js
+++ b/scripts/tarifs/edf/ejp.js
@@ -1,6 +1,7 @@
 abonnements.push({
     name: "EDF - EJP",
     lastUpdate: "2024-01-19",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 9,

--- a/scripts/tarifs/edf/tempo.js
+++ b/scripts/tarifs/edf/tempo.js
@@ -1,6 +1,7 @@
 abonnements.push({
     name: "EDF - Tempo",
     lastUpdate: "2023-08-01",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 6,

--- a/scripts/tarifs/edf/vert.js
+++ b/scripts/tarifs/edf/vert.js
@@ -2,6 +2,7 @@ abonnements.push(
     {
         name: "EDF - Vert Electrique",
         lastUpdate: "2023-09-14",
+        shiftTime: 30,        
         prices: [{
             puissance: 3,
             abonnement: 9.47,

--- a/scripts/tarifs/edf/vertHC.js
+++ b/scripts/tarifs/edf/vertHC.js
@@ -1,6 +1,7 @@
 abonnements.push({
     name: "EDF - Vert Electrique Heures Creuses",
     lastUpdate: "2023-08-01",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 6,

--- a/scripts/tarifs/edf/zenFixe.js
+++ b/scripts/tarifs/edf/zenFixe.js
@@ -2,6 +2,7 @@ abonnements.push(
     {
         name: "EDF - Zen Fixe",
         lastUpdate: "2024-01-19",
+        shiftTime: 30,        
         prices: [{
             puissance: 3,
             abonnement: 9.47,

--- a/scripts/tarifs/edf/zenFixeHC.js
+++ b/scripts/tarifs/edf/zenFixeHC.js
@@ -1,6 +1,7 @@
 abonnements.push({
     name: "EDF - Zen Fixe Heures Creuses",
     lastUpdate: "2024-01-19",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 6,

--- a/scripts/tarifs/edf/zenFlex.js
+++ b/scripts/tarifs/edf/zenFlex.js
@@ -1,6 +1,7 @@
 abonnements.push({
     name: "EDF - ZenFlex",
     lastUpdate: "2023-09-14",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 6,
@@ -111,6 +112,7 @@ abonnements.push({
         end: 24
     }],
     hasHCCustom: false,
+    shiftTime: 30,
     hasSpecialDaysCustom: false,
     specialDays: [{
         name: "sobriete",

--- a/scripts/tarifs/edf/zenWeekEnd.js
+++ b/scripts/tarifs/edf/zenWeekEnd.js
@@ -2,6 +2,7 @@ abonnements.push({
     name: "EDF - ZenFlex Week-End",
     hasSpecialDaysCustom: false,
     lastUpdate: "2023-09-14",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 3,

--- a/scripts/tarifs/edf/zenWeekEndHC.js
+++ b/scripts/tarifs/edf/zenWeekEndHC.js
@@ -1,6 +1,7 @@
 abonnements.push({
     name: "EDF - Zen Week-End HC",
     lastUpdate: "2023-09-14",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 6,

--- a/scripts/tarifs/edf/zenWeekEndPlus.js
+++ b/scripts/tarifs/edf/zenWeekEndPlus.js
@@ -1,6 +1,7 @@
 abonnements.push({
     name: "EDF - Zen Week-End Plus",
     lastUpdate: "2023-09-14",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 6,

--- a/scripts/tarifs/edf/zenWeekEndPlusHC.js
+++ b/scripts/tarifs/edf/zenWeekEndPlusHC.js
@@ -1,6 +1,7 @@
 abonnements.push({
     name: "EDF - Zen Week-End Plus HC",
     lastUpdate: "2023-09-14",
+    shiftTime: 30,    
     prices: [
         {
             puissance: 6,


### PR DESCRIPTION
Concerne l'issue #23 

Voici ma proposition de correctif pour le calcul des HC / HP EDF.



**Le principe de base**:
L'horaire indiquée dans le fichier EDF indique la fourchette haute de la tranche de consommation.
Pour déterminer correctement le classement HP / HC il faut alors diminuer de 30min l'horaire du fichier.

**Modifications apportées**
1) Ajout d'un attribut _shiftTime_ dans les fichiers tarifs/edf
Il est optionnel et représente les minutes de décalage à appliquer (j'ai fait le choix d'un attribut pour s'adapter à d'autres décalages pour d'autres fournisseur si nécessaire)

2) J'ai également restructurer le code du calculateur afin de proposer une version qui me semble plus simple et intuitive.
Pas impossible que ça corrige des décalages sur d'autres forfaits/fournisseurs, à vérifier avec d'autres jeux de données.

**Test effectué**
N'ayant que mon jeu de données personnelles je n'ai pu confirmer que celui-ci.
Voici le résultat. Les chiffres sont très légèrement différents chez EDF. Je suppose que cela provient de l'arrondi des horaires HC / HP qui sont normalement 2h58 / 7h58 

J'ai comparé avec l'application HelloWatt , qui reconstruit probablement les calculs sur bases du même fichier: les résultats sont identiques.

<img width="939" alt="image" src="https://github.com/JC144/EDF_Simulateur_Prix/assets/5261697/b7c9e195-0797-4594-b9a7-64507dc09927">

:warning: A tester et valider sur des jeux de données autres que EDF Bleu HC / HP

