### PR TITLE
Mise à jour tarif Bleu EDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Un outil pour simuler les différents tarifs de fournisseurs d'électricité dep
 
 ## Derniers tarifs: 
 * Octopus : 19 Janvier 2024
-* EDF : 18 Janvier 2024
+* EDF : 1 Février 2024
 * Ekwateur : 30 janvier 2024
 * Engie : 18 Janvier 2024
 * Mint Energie : 18 Janvier 2024

--- a/scripts/tarifs/edf/bleu.js
+++ b/scripts/tarifs/edf/bleu.js
@@ -4,65 +4,65 @@ abonnements.push(
         lastUpdate: "2023-08-01",
         prices: [{
             puissance: 3,
-            abonnement: 9.47,
+            abonnement: 9.63,
             bleu: {
-                prixKwhHC: 22.76
+                prixKwhHC: 25.16
             }
         },
         {
             puissance: 6,
-            abonnement: 12.44,
+            abonnement: 12.60,
             bleu: {
-                prixKwhHC: 22.76
+                prixKwhHC: 25.16
             }
         },
         {
             puissance: 9,
-            abonnement: 15.63,
+            abonnement: 15.79,
             bleu: {
-                prixKwhHC: 22.76
+                prixKwhHC: 25.16
             }
         },
         {
             puissance: 12,
-            abonnement: 18.89,
+            abonnement: 19.04,
             bleu: {
-                prixKwhHC: 22.76
+                prixKwhHC: 25.16
             }
         },
         {
             puissance: 15,
-            abonnement: 21.92,
+            abonnement: 22.07,
             bleu: {
-                prixKwhHC: 22.76
+                prixKwhHC: 25.16
             }
         },
         {
             puissance: 18,
-            abonnement: 24.92,
+            abonnement: 25.09,
             bleu: {
-                prixKwhHC: 22.76
+                prixKwhHC: 25.16
             }
         },
         {
             puissance: 24,
-            abonnement: 31.60,
+            abonnement: 31.76,
             bleu: {
-                prixKwhHC: 22.76
+                prixKwhHC: 25.16
             }
         },
         {
             puissance: 30,
-            abonnement: 37.29,
+            abonnement: 37.44,
             bleu: {
-                prixKwhHC: 22.76
+                prixKwhHC: 25.16
             }
         },
         {
             puissance: 36,
-            abonnement: 44.66,
+            abonnement: 44.82,
             bleu: {
-                prixKwhHC: 22.76
+                prixKwhHC: 25.16
             }
         }],
         hc: [{

--- a/scripts/tarifs/edf/bleu.js
+++ b/scripts/tarifs/edf/bleu.js
@@ -1,7 +1,7 @@
 abonnements.push(
     {
         name: "EDF - Bleu",
-        lastUpdate: "2023-08-01",
+        lastUpdate: "2024-02-01",
         prices: [{
             puissance: 3,
             abonnement: 9.63,

--- a/scripts/tarifs/edf/bleuHC.js
+++ b/scripts/tarifs/edf/bleuHC.js
@@ -1,6 +1,6 @@
 abonnements.push({
     name: "EDF - Bleu Heures Creuses",
-    lastUpdate: "2023-08-01",
+    lastUpdate: "2024-02-01",
     prices: [
         {
             puissance: 6,

--- a/scripts/tarifs/edf/bleuHC.js
+++ b/scripts/tarifs/edf/bleuHC.js
@@ -4,66 +4,66 @@ abonnements.push({
     prices: [
         {
             puissance: 6,
-            abonnement: 12.85,
+            abonnement: 13.01,
             bleu: {
-                prixKwhHP: 24.60,
-                prixKwhHC: 18.28
+                prixKwhHP: 27.00,
+                prixKwhHC: 20.68
             }
         },
         {
             puissance: 9,
-            abonnement: 16.55,
+            abonnement: 16.70,
             bleu: {
-                prixKwhHP: 24.60,
-                prixKwhHC: 18.28
+                prixKwhHP: 27.00,
+                prixKwhHC: 20.68
             }
         },
         {
             puissance: 12,
-            abonnement: 19.97,
+            abonnement: 20.13,
             bleu: {
-                prixKwhHP: 24.60,
-                prixKwhHC: 18.28
+                prixKwhHP: 27.00,
+                prixKwhHC: 20.68
             }
         },
         {
             puissance: 15,
-            abonnement: 23.24,
+            abonnement: 23.40,
             bleu: {
-                prixKwhHP: 24.60,
-                prixKwhHC: 18.28
+                prixKwhHP: 27.00,
+                prixKwhHC: 20.68
             }
         },
         {
             puissance: 18,
-            abonnement: 26.48,
+            abonnement: 26.64,
             bleu: {
-                prixKwhHP: 24.60,
-                prixKwhHC: 18.28
+                prixKwhHP: 27.00,
+                prixKwhHC: 20.68
             }
         },
         {
             puissance: 24,
-            abonnement: 33.28,
+            abonnement: 33.44,
             bleu: {
-                prixKwhHP: 24.60,
-                prixKwhHC: 18.28
+                prixKwhHP: 27.00,
+                prixKwhHC: 20.68
             }
         },
         {
             puissance: 30,
-            abonnement: 39.46,
+            abonnement: 39.63,
             bleu: {
-                prixKwhHP: 24.60,
-                prixKwhHC: 18.28
+                prixKwhHP: 27.00,
+                prixKwhHC: 20.68
             }
         },
         {
             puissance: 36,
-            abonnement: 44.64,
+            abonnement: 44.79,
             bleu: {
-                prixKwhHP: 24.60,
-                prixKwhHC: 18.28
+                prixKwhHP: 27.00,
+                prixKwhHC: 20.68
             }
         }],
     hc: [],

--- a/scripts/tarifs/edf/tempo.js
+++ b/scripts/tarifs/edf/tempo.js
@@ -1,117 +1,117 @@
 abonnements.push({
     name: "EDF - Tempo",
-    lastUpdate: "2023-08-01",
+    lastUpdate: "2024-02-01",
     prices: [
         {
             puissance: 6,
-            abonnement: 12.80,
+            abonnement: 12.96,
             bleu: {
-                prixKwhHP: 13.69,
-                prixKwhHC: 10.56
+                prixKwhHP: 16.09,
+                prixKwhHC: 12.96
             },
             blanc: {
-                prixKwhHP: 16.54,
-                prixKwhHC: 12.46
+                prixKwhHP: 18.94,
+                prixKwhHC: 14.86
             },
             rouge: {
-                prixKwhHP: 73.24,
-                prixKwhHC: 13.28
+                prixKwhHP: 75.62,
+                prixKwhHC: 15.68
             }
         },
         {
             puissance: 9,
-            abonnement: 16.00,
+            abonnement: 16.16,
             bleu: {
-                prixKwhHP: 13.69,
-                prixKwhHC: 10.56
+                prixKwhHP: 16.09,
+                prixKwhHC: 12.96
             },
             blanc: {
-                prixKwhHP: 16.54,
-                prixKwhHC: 12.46
+                prixKwhHP: 18.94,
+                prixKwhHC: 14.86
             },
             rouge: {
-                prixKwhHP: 73.24,
-                prixKwhHC: 13.28
+                prixKwhHP: 75.62,
+                prixKwhHC: 15.68
             }
         },
         {
             puissance: 12,
-            abonnement: 19.29,
+            abonnement: 19.44,
             bleu: {
-                prixKwhHP: 13.69,
-                prixKwhHC: 10.56
+                prixKwhHP: 16.09,
+                prixKwhHC: 12.96
             },
             blanc: {
-                prixKwhHP: 16.54,
-                prixKwhHC: 12.46
+                prixKwhHP: 18.94,
+                prixKwhHC: 14.86
             },
             rouge: {
-                prixKwhHP: 73.24,
-                prixKwhHC: 13.28
+                prixKwhHP: 75.62,
+                prixKwhHC: 15.68
             }
         },
         {
             puissance: 15,
-            abonnement: 22.30,
+            abonnement: 22.45,
             bleu: {
-                prixKwhHP: 13.69,
-                prixKwhHC: 10.56
+                prixKwhHP: 16.09,
+                prixKwhHC: 12.96
             },
             blanc: {
-                prixKwhHP: 16.54,
-                prixKwhHC: 12.46
+                prixKwhHP: 18.94,
+                prixKwhHC: 14.86
             },
             rouge: {
-                prixKwhHP: 73.24,
-                prixKwhHC: 13.28
+                prixKwhHP: 75.62,
+                prixKwhHC: 15.68
             }
         },
         {
             puissance: 18,
-            abonnement: 25.29,
+            abonnement: 25.44,
             bleu: {
-                prixKwhHP: 13.69,
-                prixKwhHC: 10.56
+                prixKwhHP: 16.09,
+                prixKwhHC: 12.96
             },
             blanc: {
-                prixKwhHP: 16.54,
-                prixKwhHC: 12.46
+                prixKwhHP: 18.94,
+                prixKwhHC: 14.86
             },
             rouge: {
-                prixKwhHP: 73.24,
-                prixKwhHC: 13.28
+                prixKwhHP: 75.62,
+                prixKwhHC: 15.68
             }
         },
         {
             puissance: 30,
-            abonnement: 38.13,
+            abonnement: 38.29,
             bleu: {
-                prixKwhHP: 13.69,
-                prixKwhHC: 10.56
+                prixKwhHP: 16.09,
+                prixKwhHC: 12.96
             },
             blanc: {
-                prixKwhHP: 16.54,
-                prixKwhHC: 12.46
+                prixKwhHP: 18.94,
+                prixKwhHC: 14.86
             },
             rouge: {
-                prixKwhHP: 73.24,
-                prixKwhHC: 13.28
+                prixKwhHP: 75.62,
+                prixKwhHC: 15.68
             }
         },
         {
             puissance: 36,
-            abonnement: 44.28,
+            abonnement: 44.42,
             bleu: {
-                prixKwhHP: 13.69,
-                prixKwhHC: 10.56
+                prixKwhHP: 16.09,
+                prixKwhHC: 12.96
             },
             blanc: {
-                prixKwhHP: 16.54,
-                prixKwhHC: 12.46
+                prixKwhHP: 18.94,
+                prixKwhHC: 14.86
             },
             rouge: {
-                prixKwhHP: 73.24,
-                prixKwhHC: 13.28
+                prixKwhHP: 75.62,
+                prixKwhHC: 15.68
             }
         }],
     hc: [{


### PR DESCRIPTION
Mise à jour tarif 1er Février 2024 selon grille : https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_Tarif_Bleu.pdf