### PR TITLE
Fix/fix half hour hc range

### DIFF
--- a/scripts/calculator.js
+++ b/scripts/calculator.js
@@ -137,6 +137,15 @@ function sumMonthData(monthData) {
 }
 
 function isHC(timeInformation, hcTimeBegin, hcTimeEnd) {
-    return (timeInformation.hour > hcTimeBegin.hour || timeInformation.hour == hcTimeBegin.hour && timeInformation.minute >= hcTimeBegin.minute)
-        && (timeInformation.hour < hcTimeEnd.hour);
+  begin = hcTimeBegin.hour + (hcTimeBegin.minute === 30 ? 0.5 : 0);
+  end = hcTimeEnd.hour + (hcTimeEnd.minute === 30 ? 0.5 : 0);
+  time = timeInformation.hour + (timeInformation.minute === 30 ? 0.5 : 0);
+
+  if (timeInformation.hour === 0 && timeInformation.minute === 0) {
+    time = 24;
+  }
+
+  const isHC = time > begin && time <= end;
+
+  return isHC;
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -191,14 +191,14 @@ function formatHCRange(rawStart, rawEnd) {
 
     if (startMinutes > 30) {
         startHours++;
+        startMinutes = 0;
     }
-    startMinutes = 0;
 
     //Permet de gérer le 23:59
     if (endMinutes > 30) {
         endHours++;
+        endMinutes = 0;
     }
-    endMinutes = 0;
 
     if (startHours >= endHours) {
         return null;


### PR DESCRIPTION
- Prise en compte des demi heures pour déterminer si le timeRange est dans une heure creuse
- Fix pour conserver les demi heures sur les formatage des HCRange

Testé sur export EDF uniquement, les valeurs en kWh sont identiques à celles affichées sur le site EDF

![Capture d’écran 2024-02-01 à 22 44 25](https://github.com/JC144/EDF_Simulateur_Prix/assets/902388/b423a00c-70f4-4ef6-9946-784f10e86a60)

![Capture d’écran 2024-02-01 à 22 44 07](https://github.com/JC144/EDF_Simulateur_Prix/assets/902388/a01e9d85-993b-4507-bbf9-561f2956ecaf)
