### PR TITLE
Ajout des fournisseurs Switch et Alterna

### DIFF
--- a/index.html
+++ b/index.html
@@ -502,11 +502,8 @@
     <script src="./scripts/tarifs/mint/smartEtGreen.js"></script>
     <script src="./scripts/tarifs/mint/smartEtGreenHC.js"></script>
 
-    <!-- Désactivé en attente de mise à jour-->
-	<!-- 
     <script src="./scripts/tarifs/octopus/base.js"></script>
     <script src="./scripts/tarifs/octopus/baseHC.js"></script>
-    -->
 
     <script src="./scripts/tarifs/ohm/classique.js"></script>
     <script src="./scripts/tarifs/ohm/classiqueHC.js"></script>
@@ -518,6 +515,9 @@
     <script src="./scripts/tarifs/total/heuresEcoHC.js"></script>
     <script src="./scripts/tarifs/total/offreVerteFixe.js"></script>
     <script src="./scripts/tarifs/total/offreVerteFixeHC.js"></script>
+
+    <script src="./scripts/tarifs/switch/baseHC.js"></script>
+    <script src="./scripts/tarifs/switch/base.js"></script>
     
     <script src="./scripts/parsers/edfParser.js"></script>
     <script src="./scripts/parsers/enedisParser.js"></script>

--- a/index.html
+++ b/index.html
@@ -518,6 +518,11 @@
 
     <script src="./scripts/tarifs/switch/baseHC.js"></script>
     <script src="./scripts/tarifs/switch/base.js"></script>
+
+    <script src="./scripts/tarifs/alterna/baseHC_france.js"></script>
+    <script src="./scripts/tarifs/alterna/baseHC_local.js"></script>
+    <script src="./scripts/tarifs/alterna/base_france.js"></script>
+    <script src="./scripts/tarifs/alterna/base_local.js"></script>
     
     <script src="./scripts/parsers/edfParser.js"></script>
     <script src="./scripts/parsers/enedisParser.js"></script>

--- a/scripts/tarifs/alterna/baseHC_france.js
+++ b/scripts/tarifs/alterna/baseHC_france.js
@@ -1,0 +1,77 @@
+abonnements.push({
+    name: "Octopus - Heures Creuses",
+    lastUpdate: "2024-01-19",
+    prices: [
+        {
+            puissance: 6,
+            abonnement: 13.19,
+            bleu: {
+                prixKwhHP: 27.24,
+                prixKwhHC: 20.86
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 16.70,
+            bleu: {
+                prixKwhHP: 27.24,
+                prixKwhHC: 20.86
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 20.13,
+            bleu: {
+                prixKwhHP: 27.24,
+                prixKwhHC: 20.86
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 23.40,
+            bleu: {
+                prixKwhHP: 27.24,
+                prixKwhHC: 20.86
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 26.64,
+            bleu: {
+                prixKwhHP: 27.24,
+                prixKwhHC: 20.86
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 33.44,
+            bleu: {
+                prixKwhHP: 27.24,
+                prixKwhHC: 20.86
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 39.63,
+            bleu: {
+                prixKwhHP: 27.24,
+                prixKwhHC: 20.86
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 45.88,
+            bleu: {
+                prixKwhHP: 27.24,
+                prixKwhHC: 20.86
+            }
+        }],
+    hc: [],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        let dayType = "bleu";
+        return dayType;
+    }
+});

--- a/scripts/tarifs/alterna/baseHC_local.js
+++ b/scripts/tarifs/alterna/baseHC_local.js
@@ -1,0 +1,77 @@
+abonnements.push({
+    name: "Alterna - Heures Creuses Locale",
+    lastUpdate: "2024-02-08",
+    prices: [
+        {
+            puissance: 6,
+            abonnement: 14.32,
+            bleu: {
+                prixKwhHP: 24.06,
+                prixKwhHC: 18.49
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 18.12,
+            bleu: {
+                prixKwhHP: 24.06,
+                prixKwhHC: 18.49
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 21.83,
+            bleu: {
+                prixKwhHP: 24.06,
+                prixKwhHC: 18.49
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 25.37,
+            bleu: {
+                prixKwhHP: 24.06,
+                prixKwhHC: 18.49
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 28.87,
+            bleu: {
+                prixKwhHP: 24.06,
+                prixKwhHC: 18.49
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 36.23,
+            bleu: {
+                prixKwhHP: 24.06,
+                prixKwhHC: 18.49
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 42.92,
+            bleu: {
+                prixKwhHP: 24.06,
+                prixKwhHC: 18.49
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 49.66,
+            bleu: {
+                prixKwhHP: 24.06,
+                prixKwhHC: 18.49
+            }
+        }],
+    hc: [],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        let dayType = "bleu";
+        return dayType;
+    }
+});

--- a/scripts/tarifs/alterna/base_france.js
+++ b/scripts/tarifs/alterna/base_france.js
@@ -1,0 +1,81 @@
+abonnements.push(
+    {
+        name: "Alterna - Base France",
+        lastUpdate: "2024-02-08",
+        prices: [{
+            puissance: 3,
+            abonnement: 9.69,
+            bleu: {
+                prixKwhHC: 25.39
+            }
+        },
+        {
+            puissance: 6,
+            abonnement: 12.78,
+            bleu: {
+                prixKwhHC: 25.39
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 16.06,
+            bleu: {
+                prixKwhHC: 25.39
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 19.40,
+            bleu: {
+                prixKwhHC: 25.39
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 22.53,
+            bleu: {
+                prixKwhHC: 25.39
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 25.63,
+            bleu: {
+                prixKwhHC: 25.39
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 32.48,
+            bleu: {
+                prixKwhHC: 25.39
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 38.35,
+            bleu: {
+                prixKwhHC: 25.39
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 45.23,
+            bleu: {
+                prixKwhHC: 25.39
+            }
+        }],
+        hc: [{
+            start: {hour:0, minute:0},
+            end: {hour:24, minute:0}
+        }],
+        hasHCCustom: false,
+        hasSpecialDaysCustom: false,
+        specialDays: [],
+        getDayType: function (day) {
+            let dayType = "bleu";
+            return dayType;
+        }
+    }
+);
+

--- a/scripts/tarifs/alterna/base_local.js
+++ b/scripts/tarifs/alterna/base_local.js
@@ -1,0 +1,81 @@
+abonnements.push(
+    {
+        name: "Alterna - Base Locale",
+        lastUpdate: "2024-02-08",
+        prices: [{
+            puissance: 3,
+            abonnement: 10.53,
+            bleu: {
+                prixKwhHC: 22.45
+            }
+        },
+        {
+            puissance: 6,
+            abonnement: 13.87,
+            bleu: {
+                prixKwhHC: 22.45
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 17.42,
+            bleu: {
+                prixKwhHC: 22.45
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 21.03,
+            bleu: {
+                prixKwhHC: 22.45
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 24.40,
+            bleu: {
+                prixKwhHC: 22.45
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 27.75,
+            bleu: {
+                prixKwhHC: 22.45
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 35.17,
+            bleu: {
+                prixKwhHC: 22.45
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 41.50,
+            bleu: {
+                prixKwhHC: 22.45
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 48.95,
+            bleu: {
+                prixKwhHC: 22.45
+            }
+        }],
+        hc: [{
+            start: {hour:0, minute:0},
+            end: {hour:24, minute:0}
+        }],
+        hasHCCustom: false,
+        hasSpecialDaysCustom: false,
+        specialDays: [],
+        getDayType: function (day) {
+            let dayType = "bleu";
+            return dayType;
+        }
+    }
+);
+

--- a/scripts/tarifs/switch/base.js
+++ b/scripts/tarifs/switch/base.js
@@ -1,0 +1,81 @@
+abonnements.push(
+    {
+        name: "Switch - Base",
+        lastUpdate: "2024-02-08",
+        prices: [{
+            puissance: 3,
+            abonnement: 9.38,
+            bleu: {
+                prixKwhHC: 19.95
+            }
+        },
+        {
+            puissance: 6,
+            abonnement: 12.27,
+            bleu: {
+                prixKwhHC: 19.95
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 15.38,
+            bleu: {
+                prixKwhHC: 19.95
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 18.55,
+            bleu: {
+                prixKwhHC: 19.95
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 21.51,
+            bleu: {
+                prixKwhHC: 19.95
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 24.45,
+            bleu: {
+                prixKwhHC: 19.95
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 30.95,
+            bleu: {
+                prixKwhHC: 19.95
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 36.50,
+            bleu: {
+                prixKwhHC: 19.95
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 43.03,
+            bleu: {
+                prixKwhHC: 19.95
+            }
+        }],
+        hc: [{
+            start: {hour:0, minute:0},
+            end: {hour:24, minute:0}
+        }],
+        hasHCCustom: false,
+        hasSpecialDaysCustom: false,
+        specialDays: [],
+        getDayType: function (day) {
+            let dayType = "bleu";
+            return dayType;
+        }
+    }
+);
+

--- a/scripts/tarifs/switch/baseHC.js
+++ b/scripts/tarifs/switch/baseHC.js
@@ -1,0 +1,77 @@
+abonnements.push({
+    name: "Switch - Heures Creuses",
+    lastUpdate: "2024-02-08",
+    prices: [
+        {
+            puissance: 6,
+            abonnement: 12.67,
+            bleu: {
+                prixKwhHP: 21.36,
+                prixKwhHC: 16.50
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 16.01,
+            bleu: {
+                prixKwhHP: 21.36,
+                prixKwhHC: 16.50
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 19.26,
+            bleu: {
+                prixKwhHP: 21.36,
+                prixKwhHC: 16.50
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 22.36,
+            bleu: {
+                prixKwhHP: 21.36,
+                prixKwhHC: 16.50
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 25.43,
+            bleu: {
+                prixKwhHP: 21.36,
+                prixKwhHC: 16.50
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 31.88,
+            bleu: {
+                prixKwhHP: 21.36,
+                prixKwhHC: 16.50
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 37.75,
+            bleu: {
+                prixKwhHP: 21.36,
+                prixKwhHC: 16.50
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 43.66,
+            bleu: {
+                prixKwhHP: 21.36,
+                prixKwhHC: 16.50
+            }
+        }],
+    hc: [],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        let dayType = "bleu";
+        return dayType;
+    }
+});


### PR DESCRIPTION
Ajout du fournisseur Switch.
Grille tarifaire : https://api.chezswitch.fr/docs/2024.02.01_Grille_tarifaire_des_offres_delectricite.pdf?v=30
Site : https://www.chezswitch.fr/offre-energie/