### PR TITLE
Update EDF Offres de Marché (01-11-2024)

### DIFF
--- a/scripts/tarifs/edf/vert.js
+++ b/scripts/tarifs/edf/vert.js
@@ -2,69 +2,69 @@ abonnements.push(
     {
         name: "EDF - Vert Electrique",
         offer_type: "TRV",
-        lastUpdate: "2024-03-19",
+        lastUpdate: "2024-11-01",
         isCommunity: false,
         subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique.html",
         price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique.pdf",
         prices: [{
             puissance: 3,
-            abonnement: 9.63,
+            abonnement: 9.69,
             bleu: {
                 prixKwhHC: 24.23
             }
         },
         {
             puissance: 6,
-            abonnement: 12.60,
+            abonnement: 12.68,
             bleu: {
                 prixKwhHC: 24.23
             }
         },
         {
             puissance: 9,
-            abonnement: 15.79,
+            abonnement: 15.89,
             bleu: {
                 prixKwhHC: 24.23
             }
         },
         {
             puissance: 12,
-            abonnement: 19.04,
+            abonnement: 19.16,
             bleu: {
                 prixKwhHC: 24.23
             }
         },
         {
             puissance: 15,
-            abonnement: 22.08,
+            abonnement: 22.21,
             bleu: {
                 prixKwhHC: 24.23
             }
         },
         {
             puissance: 18,
-            abonnement: 25.09,
+            abonnement: 25.24,
             bleu: {
                 prixKwhHC: 24.23
             }
         },
         {
             puissance: 24,
-            abonnement: 31.76,
+            abonnement: 31.96,
             bleu: {
                 prixKwhHC: 24.23
             }
         },
         {
             puissance: 30,
-            abonnement: 37.44,
+            abonnement: 37.68,
             bleu: {
                 prixKwhHC: 24.23
             }
         },
         {
             puissance: 36,
-            abonnement: 44.15,
+            abonnement: 44.43,
             bleu: {
                 prixKwhHC: 24.23
             }

--- a/scripts/tarifs/edf/vert.js
+++ b/scripts/tarifs/edf/vert.js
@@ -1,7 +1,7 @@
 abonnements.push(
     {
         name: "EDF - Vert Electrique",
-        offer_type: "TRV",
+        offer_type: "Marché",
         lastUpdate: "2024-11-01",
         isCommunity: false,
         subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique.html",

--- a/scripts/tarifs/edf/vertHC.js
+++ b/scripts/tarifs/edf/vertHC.js
@@ -1,6 +1,6 @@
 abonnements.push({
     name: "EDF - Vert Electrique Heures Creuses",
-    offer_type: "TRV",
+    offer_type: "Marché",
     lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique.html",

--- a/scripts/tarifs/edf/vertHC.js
+++ b/scripts/tarifs/edf/vertHC.js
@@ -1,14 +1,14 @@
 abonnements.push({
     name: "EDF - Vert Electrique Heures Creuses",
     offer_type: "TRV",
-    lastUpdate: "2024-03-19",
+    lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique.pdf",
     prices: [
         {
             puissance: 6,
-            abonnement: 13.01,
+            abonnement: 13.09,
             bleu: {
                 prixKwhHP: 26.18,
                 prixKwhHC: 19.86
@@ -16,7 +16,7 @@ abonnements.push({
         },
         {
             puissance: 9,
-            abonnement: 16.71,
+            abonnement: 16.82,
             bleu: {
                 prixKwhHP: 26.18,
                 prixKwhHC: 19.86
@@ -24,7 +24,7 @@ abonnements.push({
         },
         {
             puissance: 12,
-            abonnement: 20.13,
+            abonnement: 20.28,
             bleu: {
                 prixKwhHP: 26.18,
                 prixKwhHC: 19.86
@@ -32,7 +32,7 @@ abonnements.push({
         },
         {
             puissance: 15,
-            abonnement: 23.40,
+            abonnement: 23.09,
             bleu: {
                 prixKwhHP: 26.18,
                 prixKwhHC: 19.86
@@ -40,7 +40,7 @@ abonnements.push({
         },
         {
             puissance: 18,
-            abonnement: 26.64,
+            abonnement: 26.26,
             bleu: {
                 prixKwhHP: 26.18,
                 prixKwhHC: 19.86
@@ -48,7 +48,7 @@ abonnements.push({
         },
         {
             puissance: 24,
-            abonnement: 33.44,
+            abonnement: 32.92,
             bleu: {
                 prixKwhHP: 26.18,
                 prixKwhHC: 19.86
@@ -56,7 +56,7 @@ abonnements.push({
         },
         {
             puissance: 30,
-            abonnement: 38.73,
+            abonnement: 38.97,
             bleu: {
                 prixKwhHP: 26.18,
                 prixKwhHC: 19.86
@@ -64,7 +64,7 @@ abonnements.push({
         },
         {
             puissance: 36,
-            abonnement: 44.79,
+            abonnement: 45.08,
             bleu: {
                 prixKwhHP: 26.18,
                 prixKwhHC: 19.86

--- a/scripts/tarifs/edf/zenFixe.js
+++ b/scripts/tarifs/edf/zenFixe.js
@@ -1,7 +1,7 @@
 abonnements.push(
     {
         name: "EDF - Zen Fixe",
-        offer_type: "TRV",
+        offer_type: "Marché",
         lastUpdate: "2024-11-01",
         isCommunity: false,
         subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",

--- a/scripts/tarifs/edf/zenFixe.js
+++ b/scripts/tarifs/edf/zenFixe.js
@@ -2,76 +2,76 @@ abonnements.push(
     {
         name: "EDF - Zen Fixe",
         offer_type: "TRV",
-        lastUpdate: "2024-07-01",
+        lastUpdate: "2024-11-01",
         isCommunity: false,
         subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",
         price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",
         prices: [{
             puissance: 3,
-            abonnement: 9.63,
+            abonnement: 9.69,
             bleu: {
                 prixKwhHC: 20.64
             }
         },
         {
             puissance: 6,
-            abonnement: 12.60,
+            abonnement: 12.67,
             bleu: {
                 prixKwhHC: 20.64
             }
         },
         {
             puissance: 9,
-            abonnement: 15.79,
+            abonnement: 15.89,
             bleu: {
                 prixKwhHC: 20.64
             }
         },
         {
             puissance: 12,
-            abonnement: 19.04,
+            abonnement: 19.16,
             bleu: {
                 prixKwhHC: 20.64
             }
         },
         {
             puissance: 15,
-            abonnement: 22.07,
+            abonnement: 22.21,
             bleu: {
                 prixKwhHC: 20.64
             }
         },
         {
             puissance: 18,
-            abonnement: 25.09,
+            abonnement: 25.24,
             bleu: {
                 prixKwhHC: 20.64
             }
         },
         {
             puissance: 24,
-            abonnement: 31.76,
+            abonnement: 31.96,
             bleu: {
                 prixKwhHC: 20.64
             }
         },
         {
             puissance: 30,
-            abonnement: 37.44,
+            abonnement: 37.68,
             bleu: {
                 prixKwhHC: 20.64
             }
         },
         {
             puissance: 36,
-            abonnement: 44.15,
+            abonnement: 44.43,
             bleu: {
                 prixKwhHC: 20.64
             }
         }],
         hc: [{
-            start: {hour:0, minute:0},
-            end: {hour:24, minute:0}
+            start: { hour: 0, minute: 0 },
+            end: { hour: 24, minute: 0 }
         }],
         hasHCCustom: false,
         hasSpecialDaysCustom: false,

--- a/scripts/tarifs/edf/zenFixeHC.js
+++ b/scripts/tarifs/edf/zenFixeHC.js
@@ -1,6 +1,6 @@
 abonnements.push({
     name: "EDF - Zen Fixe Heures Creuses",
-    offer_type: "TRV",
+    offer_type: "Marché",
     lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",

--- a/scripts/tarifs/edf/zenFixeHC.js
+++ b/scripts/tarifs/edf/zenFixeHC.js
@@ -1,14 +1,14 @@
 abonnements.push({
     name: "EDF - Zen Fixe Heures Creuses",
     offer_type: "TRV",
-    lastUpdate: "2024-07-01",
+    lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",
     prices: [
         {
             puissance: 6,
-            abonnement: 13.01,
+            abonnement: 13.09,
             bleu: {
                 prixKwhHP: 22.10,
                 prixKwhHC: 17.04
@@ -16,7 +16,7 @@ abonnements.push({
         },
         {
             puissance: 9,
-            abonnement: 16.70,
+            abonnement: 16.82,
             bleu: {
                 prixKwhHP: 22.10,
                 prixKwhHC: 17.04
@@ -24,7 +24,7 @@ abonnements.push({
         },
         {
             puissance: 12,
-            abonnement: 20.13,
+            abonnement: 20.28,
             bleu: {
                 prixKwhHP: 22.10,
                 prixKwhHC: 17.04
@@ -32,7 +32,7 @@ abonnements.push({
         },
         {
             puissance: 15,
-            abonnement: 23.40,
+            abonnement: 23.09,
             bleu: {
                 prixKwhHP: 22.10,
                 prixKwhHC: 17.04
@@ -40,7 +40,7 @@ abonnements.push({
         },
         {
             puissance: 18,
-            abonnement: 26.64,
+            abonnement: 26.26,
             bleu: {
                 prixKwhHP: 22.10,
                 prixKwhHC: 17.04
@@ -48,7 +48,7 @@ abonnements.push({
         },
         {
             puissance: 24,
-            abonnement: 33.44,
+            abonnement: 32.92,
             bleu: {
                 prixKwhHP: 22.10,
                 prixKwhHC: 17.04
@@ -56,7 +56,7 @@ abonnements.push({
         },
         {
             puissance: 30,
-            abonnement: 38.73,
+            abonnement: 38.97,
             bleu: {
                 prixKwhHP: 22.10,
                 prixKwhHC: 17.04
@@ -64,7 +64,7 @@ abonnements.push({
         },
         {
             puissance: 36,
-            abonnement: 44.79,
+            abonnement: 45.08,
             bleu: {
                 prixKwhHP: 22.10,
                 prixKwhHC: 17.04

--- a/scripts/tarifs/edf/zenFlex.js
+++ b/scripts/tarifs/edf/zenFlex.js
@@ -1,6 +1,6 @@
 abonnements.push({
     name: "EDF - ZenFlex",
-    offer_type: "TRV",
+    offer_type: "Marché",
     lastUpdate: "2024-03-19",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-flex.html",

--- a/scripts/tarifs/edf/zenWeekEnd.js
+++ b/scripts/tarifs/edf/zenWeekEnd.js
@@ -1,6 +1,6 @@
 abonnements.push({
     name: "EDF - ZenFlex Week-End",
-    offer_type: "TRV",
+    offer_type: "Marché",
     hasSpecialDaysCustom: false,
     lastUpdate: "2024-11-01",
     isCommunity: false,

--- a/scripts/tarifs/edf/zenWeekEnd.js
+++ b/scripts/tarifs/edf/zenWeekEnd.js
@@ -2,14 +2,14 @@ abonnements.push({
     name: "EDF - ZenFlex Week-End",
     offer_type: "TRV",
     hasSpecialDaysCustom: false,
-    lastUpdate: "2024-03-19",
+    lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end.pdf",
     prices: [
         {
             puissance: 3,
-            abonnement: 9.63,
+            abonnement: 9.69,
             bleu: {
                 prixKwhHC: 26.29
             },
@@ -19,7 +19,7 @@ abonnements.push({
         },
         {
             puissance: 6,
-            abonnement: 12.60,
+            abonnement: 12.68,
             bleu: {
                 prixKwhHC: 26.29
             },
@@ -29,7 +29,7 @@ abonnements.push({
         },
         {
             puissance: 9,
-            abonnement: 15.79,
+            abonnement: 15.89,
             bleu: {
                 prixKwhHC: 26.29
             },
@@ -39,7 +39,7 @@ abonnements.push({
         },
         {
             puissance: 12,
-            abonnement: 19.40,
+            abonnement: 19.16,
             bleu: {
                 prixKwhHC: 26.29
             },
@@ -49,7 +49,7 @@ abonnements.push({
         },
         {
             puissance: 15,
-            abonnement: 22.53,
+            abonnement: 22.21,
             bleu: {
                 prixKwhHC: 26.29
             },
@@ -59,7 +59,7 @@ abonnements.push({
         },
         {
             puissance: 18,
-            abonnement: 25.63,
+            abonnement: 25.24,
             bleu: {
                 prixKwhHC: 26.29
             },
@@ -69,7 +69,7 @@ abonnements.push({
         },
         {
             puissance: 24,
-            abonnement: 32.48,
+            abonnement: 32.74,
             bleu: {
                 prixKwhHC: 26.29
             },
@@ -79,7 +79,7 @@ abonnements.push({
         },
         {
             puissance: 30,
-            abonnement: 37.44,
+            abonnement: 37.68,
             bleu: {
                 prixKwhHC: 26.29
             },
@@ -89,7 +89,7 @@ abonnements.push({
         },
         {
             puissance: 36,
-            abonnement: 44.15,
+            abonnement: 44.43,
             bleu: {
                 prixKwhHC: 26.29
             },
@@ -98,8 +98,8 @@ abonnements.push({
             }
         }],
     hc: [{
-        start: {hour:0, minute:0},
-        end: {hour:24, minute:0}
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
     }],
     hasHCCustom: false,
     hasSpecialDaysCustom: false,

--- a/scripts/tarifs/edf/zenWeekEndHC.js
+++ b/scripts/tarifs/edf/zenWeekEndHC.js
@@ -1,6 +1,6 @@
 abonnements.push({
     name: "EDF - Zen Week-End HC",
-    offer_type: "TRV",
+    offer_type: "Marché",
     lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end.html",

--- a/scripts/tarifs/edf/zenWeekEndHC.js
+++ b/scripts/tarifs/edf/zenWeekEndHC.js
@@ -1,14 +1,14 @@
 abonnements.push({
     name: "EDF - Zen Week-End HC",
     offer_type: "TRV",
-    lastUpdate: "2024-03-19",
+    lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end.pdf",
     prices: [
         {
             puissance: 6,
-            abonnement: 13.19,
+            abonnement: 13.09,
             bleu: {
                 prixKwhHP: 27.88,
                 prixKwhHC: 20.27
@@ -20,7 +20,7 @@ abonnements.push({
         },
         {
             puissance: 9,
-            abonnement: 16.71,
+            abonnement: 16.82,
             bleu: {
                 prixKwhHP: 27.88,
                 prixKwhHC: 20.27
@@ -32,7 +32,7 @@ abonnements.push({
         },
         {
             puissance: 12,
-            abonnement: 20.13,
+            abonnement: 20.28,
             bleu: {
                 prixKwhHP: 27.88,
                 prixKwhHC: 20.27
@@ -44,7 +44,7 @@ abonnements.push({
         },
         {
             puissance: 15,
-            abonnement: 23.40,
+            abonnement: 23.57,
             bleu: {
                 prixKwhHP: 27.88,
                 prixKwhHC: 20.27
@@ -56,7 +56,7 @@ abonnements.push({
         },
         {
             puissance: 18,
-            abonnement: 26.64,
+            abonnement: 26.84,
             bleu: {
                 prixKwhHP: 27.88,
                 prixKwhHC: 20.27
@@ -68,7 +68,7 @@ abonnements.push({
         },
         {
             puissance: 24,
-            abonnement: 33.44,
+            abonnement: 33.70,
             bleu: {
                 prixKwhHP: 27.88,
                 prixKwhHC: 20.27
@@ -80,7 +80,7 @@ abonnements.push({
         },
         {
             puissance: 30,
-            abonnement: 39.63,
+            abonnement: 39.94,
             bleu: {
                 prixKwhHP: 27.88,
                 prixKwhHC: 20.27
@@ -92,7 +92,7 @@ abonnements.push({
         },
         {
             puissance: 36,
-            abonnement: 45.88,
+            abonnement: 46.24,
             bleu: {
                 prixKwhHP: 27.88,
                 prixKwhHC: 20.27
@@ -103,12 +103,12 @@ abonnements.push({
             }
         }],
     hc: [{
-        start: {hour:22, minute:0},
-        end: {hour:24, minute:0}
+        start: { hour: 22, minute: 0 },
+        end: { hour: 24, minute: 0 }
     },
     {
-        start: {hour:0, minute:0},
-        end: {hour:6, minute:0}
+        start: { hour: 0, minute: 0 },
+        end: { hour: 6, minute: 0 }
     }],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,

--- a/scripts/tarifs/edf/zenWeekEndPlus.js
+++ b/scripts/tarifs/edf/zenWeekEndPlus.js
@@ -1,6 +1,6 @@
 abonnements.push({
     name: "EDF - Zen Week-End Plus",
-    offer_type: "TRV",
+    offer_type: "Marché",
     lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end-plus.html",

--- a/scripts/tarifs/edf/zenWeekEndPlus.js
+++ b/scripts/tarifs/edf/zenWeekEndPlus.js
@@ -1,14 +1,14 @@
 abonnements.push({
     name: "EDF - Zen Week-End Plus",
     offer_type: "TRV",
-    lastUpdate: "2024-03-19",
+    lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end-plus.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end-plus.pdf",
     prices: [
         {
             puissance: 6,
-            abonnement: 12.60,
+            abonnement: 12.68,
             bleu: {
                 prixKwhHC: 27.64
             },
@@ -18,7 +18,7 @@ abonnements.push({
         },
         {
             puissance: 9,
-            abonnement: 16.06,
+            abonnement: 16.18,
             bleu: {
                 prixKwhHC: 27.64
             },
@@ -28,7 +28,7 @@ abonnements.push({
         },
         {
             puissance: 12,
-            abonnement: 19.40,
+            abonnement: 19.55,
             bleu: {
                 prixKwhHC: 27.64
             },
@@ -38,7 +38,7 @@ abonnements.push({
         },
         {
             puissance: 15,
-            abonnement: 22.53,
+            abonnement: 22.21,
             bleu: {
                 prixKwhHC: 27.64
             },
@@ -48,7 +48,7 @@ abonnements.push({
         },
         {
             puissance: 18,
-            abonnement: 25.63,
+            abonnement: 25.24,
             bleu: {
                 prixKwhHC: 27.64
             },
@@ -58,7 +58,7 @@ abonnements.push({
         },
         {
             puissance: 24,
-            abonnement: 32.48,
+            abonnement: 31.96,
             bleu: {
                 prixKwhHC: 27.64
             },
@@ -68,7 +68,7 @@ abonnements.push({
         },
         {
             puissance: 30,
-            abonnement: 38.35,
+            abonnement: 37.68,
             bleu: {
                 prixKwhHC: 27.64
             },
@@ -78,7 +78,7 @@ abonnements.push({
         },
         {
             puissance: 36,
-            abonnement: 44.15,
+            abonnement: 44.43,
             bleu: {
                 prixKwhHC: 27.64
             },
@@ -87,8 +87,8 @@ abonnements.push({
             }
         }],
     hc: [{
-        start: {hour:0, minute:0},
-        end: {hour:24, minute:0}
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
     }],
     hasHCCustom: false,
     hasSpecialDaysCustom: true,
@@ -98,8 +98,8 @@ abonnements.push({
 
         const isoDate = new Date(day.date);
         const dayOfWeek = isoDate.getDay();
-    
-        if (this.specialDays.includes(dayOfWeek)) {            
+
+        if (this.specialDays.includes(dayOfWeek)) {
             dayType = "weekend";
         }
 

--- a/scripts/tarifs/edf/zenWeekEndPlusHC.js
+++ b/scripts/tarifs/edf/zenWeekEndPlusHC.js
@@ -1,14 +1,14 @@
 abonnements.push({
     name: "EDF - Zen Week-End Plus HC",
     offer_type: "TRV",
-    lastUpdate: "2024-03-19",
+    lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end-plus.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end-plus.pdf",
     prices: [
         {
             puissance: 6,
-            abonnement: 13.19,
+            abonnement: 13.09,
             bleu: {
                 prixKwhHP: 28.74,
                 prixKwhHC: 20.88
@@ -20,7 +20,7 @@ abonnements.push({
         },
         {
             puissance: 9,
-            abonnement: 16.71,
+            abonnement: 16.82,
             bleu: {
                 prixKwhHP: 28.74,
                 prixKwhHC: 20.88
@@ -32,7 +32,7 @@ abonnements.push({
         },
         {
             puissance: 12,
-            abonnement: 20.13,
+            abonnement: 20.28,
             bleu: {
                 prixKwhHP: 28.74,
                 prixKwhHC: 20.88
@@ -44,7 +44,7 @@ abonnements.push({
         },
         {
             puissance: 15,
-            abonnement: 23.40,
+            abonnement: 23.57,
             bleu: {
                 prixKwhHP: 28.74,
                 prixKwhHC: 20.88
@@ -56,7 +56,7 @@ abonnements.push({
         },
         {
             puissance: 18,
-            abonnement: 26.64,
+            abonnement: 26.84,
             bleu: {
                 prixKwhHP: 28.74,
                 prixKwhHC: 20.88
@@ -68,7 +68,7 @@ abonnements.push({
         },
         {
             puissance: 24,
-            abonnement: 33.44,
+            abonnement: 33.70,
             bleu: {
                 prixKwhHP: 28.74,
                 prixKwhHC: 20.88
@@ -80,7 +80,7 @@ abonnements.push({
         },
         {
             puissance: 30,
-            abonnement: 39.63,
+            abonnement: 39.94,
             bleu: {
                 prixKwhHP: 28.74,
                 prixKwhHC: 20.88
@@ -92,7 +92,7 @@ abonnements.push({
         },
         {
             puissance: 36,
-            abonnement: 45.88,
+            abonnement: 46.24,
             bleu: {
                 prixKwhHP: 28.74,
                 prixKwhHC: 20.88
@@ -103,12 +103,12 @@ abonnements.push({
             }
         }],
     hc: [{
-        start: {hour:22, minute:0},
-        end: {hour:24, minute:0}
+        start: { hour: 22, minute: 0 },
+        end: { hour: 24, minute: 0 }
     },
     {
-        start: {hour:0, minute:0},
-        end: {hour:6, minute:0}
+        start: { hour: 0, minute: 0 },
+        end: { hour: 6, minute: 0 }
     }],
     hasHCCustom: true,
     hasSpecialDaysCustom: true,

--- a/scripts/tarifs/edf/zenWeekEndPlusHC.js
+++ b/scripts/tarifs/edf/zenWeekEndPlusHC.js
@@ -1,6 +1,6 @@
 abonnements.push({
     name: "EDF - Zen Week-End Plus HC",
-    offer_type: "TRV",
+    offer_type: "Marché",
     lastUpdate: "2024-11-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end-plus.html",


### PR DESCRIPTION
Mise à jour des grilles tarifaires EDF (offres de marché) suite à la hausse du TURPE au 1er novembre 2024
Je me suis également permis de corriger le offer_type erroné pour l'ensemble de ces offres