### PR TITLE
Add missing EDF Vert Elec offers

### DIFF
--- a/index.html
+++ b/index.html
@@ -562,6 +562,11 @@
     <script src="./scripts/tarifs/edf/tempo.js"></script>
     <script src="./scripts/tarifs/edf/vert.js"></script>
     <script src="./scripts/tarifs/edf/vertHC.js"></script>
+    <script src="./scripts/tarifs/edf/vertAuto.js"></script>
+    <script src="./scripts/tarifs/edf/vertRegional.js"></script>
+    <script src="./scripts/tarifs/edf/vertRegionalHC.js"></script>
+    <script src="./scripts/tarifs/edf/vertWeekEnd.js"></script>
+    <script src="./scripts/tarifs/edf/vertWeekEndHC.js"></script>
     <script src="./scripts/tarifs/edf/zenFixe.js"></script>
     <script src="./scripts/tarifs/edf/zenFixeHC.js"></script>
     <script src="./scripts/tarifs/edf/zenFlex.js"></script>

--- a/scripts/tarifs/edf/vertAuto.js
+++ b/scripts/tarifs/edf/vertAuto.js
@@ -1,0 +1,81 @@
+abonnements.push({
+    name: "EDF - Vert Electrique Auto",
+    offer_type: "Marché",
+    lastUpdate: "2024-11-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-auto.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-auto.pdf",
+    prices: [
+        {
+            puissance: 6,
+            abonnement: 13.28,
+            bleu: {
+                prixKwhHP: 29.53,
+                prixKwhHC: 16.03
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 16.82,
+            bleu: {
+                prixKwhHP: 29.53,
+                prixKwhHC: 16.03
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 20.28,
+            bleu: {
+                prixKwhHP: 29.53,
+                prixKwhHC: 16.03
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 23.57,
+            bleu: {
+                prixKwhHP: 29.53,
+                prixKwhHC: 16.03
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 26.84,
+            bleu: {
+                prixKwhHP: 29.53,
+                prixKwhHC: 16.03
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 33.70,
+            bleu: {
+                prixKwhHP: 29.53,
+                prixKwhHC: 16.03
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 39.94,
+            bleu: {
+                prixKwhHP: 29.53,
+                prixKwhHC: 16.03
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 45.08,
+            bleu: {
+                prixKwhHP: 29.53,
+                prixKwhHC: 16.03
+            }
+        }],
+    hc: [],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        let dayType = "bleu";
+        return dayType;
+    }
+});

--- a/scripts/tarifs/edf/vertRegional.js
+++ b/scripts/tarifs/edf/vertRegional.js
@@ -1,0 +1,76 @@
+abonnements.push({
+    name: "EDF - Vert Electrique Régional",
+    offer_type: "Marché",
+    lastUpdate: "2024-11-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-regional.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-regional.pdf",
+    prices: [
+        {
+            puissance: 6,
+            abonnement: 12.68,
+            bleu: {
+                prixKwhHC: 24.84
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 15.89,
+            bleu: {
+                prixKwhHC: 24.88
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 19.16,
+            bleu: {
+                prixKwhHC: 24.88
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 22.21,
+            bleu: {
+                prixKwhHC: 24.88
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 25.24,
+            bleu: {
+                prixKwhHC: 24.88
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 31.96,
+            bleu: {
+                prixKwhHC: 24.88
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 37.68,
+            bleu: {
+                prixKwhHC: 24.88
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 45.60,
+            bleu: {
+                prixKwhHC: 24.88
+            }
+        }],
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        let dayType = "bleu";
+        return dayType;
+    }
+});

--- a/scripts/tarifs/edf/vertRegionalHC.js
+++ b/scripts/tarifs/edf/vertRegionalHC.js
@@ -1,0 +1,81 @@
+abonnements.push({
+    name: "EDF - Vert Electrique Régional Heures Creuses",
+    offer_type: "Marché",
+    lastUpdate: "2024-11-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-regional.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-regional.pdf",
+    prices: [
+        {
+            puissance: 6,
+            abonnement: 13.09,
+            bleu: {
+                prixKwhHP: 27.70,
+                prixKwhHC: 19.03
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 16.82,
+            bleu: {
+                prixKwhHP: 27.70,
+                prixKwhHC: 19.03
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 20.28,
+            bleu: {
+                prixKwhHP: 27.70,
+                prixKwhHC: 19.03
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 23.57,
+            bleu: {
+                prixKwhHP: 27.70,
+                prixKwhHC: 19.03
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 26.26,
+            bleu: {
+                prixKwhHP: 27.70,
+                prixKwhHC: 19.03
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 32.92,
+            bleu: {
+                prixKwhHP: 27.70,
+                prixKwhHC: 19.03
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 38.97,
+            bleu: {
+                prixKwhHP: 27.70,
+                prixKwhHC: 19.03
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 45.08,
+            bleu: {
+                prixKwhHP: 27.70,
+                prixKwhHC: 19.03
+            }
+        }],
+    hc: [],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        let dayType = "bleu";
+        return dayType;
+    }
+});

--- a/scripts/tarifs/edf/vertWeekEnd.js
+++ b/scripts/tarifs/edf/vertWeekEnd.js
@@ -1,0 +1,108 @@
+abonnements.push({
+    name: "EDF - Vert Electrique Week-End",
+    offer_type: "Marché",
+    lastUpdate: "2024-11-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-week-end.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-weekend.pdf",
+    prices: [
+        {
+            puissance: 6,
+            abonnement: 12.68,
+            bleu: {
+                prixKwhHC: 26.58
+            },
+            weekend: {
+                prixKwhHC: 19.37
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 15.89,
+            bleu: {
+                prixKwhHC: 26.58
+            },
+            weekend: {
+                prixKwhHC: 19.37
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 19.16,
+            bleu: {
+                prixKwhHC: 26.58
+            },
+            weekend: {
+                prixKwhHC: 19.37
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 22.21,
+            bleu: {
+                prixKwhHC: 26.58
+            },
+            weekend: {
+                prixKwhHC: 19.37
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 25.24,
+            bleu: {
+                prixKwhHC: 26.58
+            },
+            weekend: {
+                prixKwhHC: 19.37
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 31.96,
+            bleu: {
+                prixKwhHC: 26.58
+            },
+            weekend: {
+                prixKwhHC: 19.37
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 38.66,
+            bleu: {
+                prixKwhHC: 26.58
+            },
+            weekend: {
+                prixKwhHC: 19.37
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 44.43,
+            bleu: {
+                prixKwhHC: 26.58
+            },
+            weekend: {
+                prixKwhHC: 19.37
+            }
+        }],
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [0, 6],
+    getDayType: function (day) {
+        let dayType = "bleu";
+
+        const isoDate = new Date(day.date);
+        const dayOfWeek = isoDate.getDay();
+
+        if (this.specialDays.includes(dayOfWeek)) {
+            dayType = "weekend";
+        }
+
+        return dayType;
+    }
+});

--- a/scripts/tarifs/edf/vertWeekEndHC.js
+++ b/scripts/tarifs/edf/vertWeekEndHC.js
@@ -1,0 +1,128 @@
+abonnements.push({
+    name: "EDF - Vert Electrique Week-End Heures Creuses",
+    offer_type: "Marché",
+    lastUpdate: "2024-11-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-week-end.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-weekend.pdf",
+    prices: [
+        {
+            puissance: 6,
+            abonnement: 13.09,
+            bleu: {
+                prixKwhHP: 28.16,
+                prixKwhHC: 20.47
+            },
+            weekend: {
+                prixKwhHP: 20.47,
+                prixKwhHC: 20.47
+            }
+        },
+        {
+            puissance: 9,
+            abonnement: 16.82,
+            bleu: {
+                prixKwhHP: 28.16,
+                prixKwhHC: 20.47
+            },
+            weekend: {
+                prixKwhHP: 20.47,
+                prixKwhHC: 20.47
+            }
+        },
+        {
+            puissance: 12,
+            abonnement: 20.28,
+            bleu: {
+                prixKwhHP: 28.16,
+                prixKwhHC: 20.47
+            },
+            weekend: {
+                prixKwhHP: 20.47,
+                prixKwhHC: 20.47
+            }
+        },
+        {
+            puissance: 15,
+            abonnement: 23.57,
+            bleu: {
+                prixKwhHP: 28.16,
+                prixKwhHC: 20.47
+            },
+            weekend: {
+                prixKwhHP: 20.47,
+                prixKwhHC: 20.47
+            }
+        },
+        {
+            puissance: 18,
+            abonnement: 26.84,
+            bleu: {
+                prixKwhHP: 28.16,
+                prixKwhHC: 20.47
+            },
+            weekend: {
+                prixKwhHP: 20.47,
+                prixKwhHC: 20.47
+            }
+        },
+        {
+            puissance: 24,
+            abonnement: 33.70,
+            bleu: {
+                prixKwhHP: 28.16,
+                prixKwhHC: 20.47
+            },
+            weekend: {
+                prixKwhHP: 20.47,
+                prixKwhHC: 20.47
+            }
+        },
+        {
+            puissance: 30,
+            abonnement: 39.94,
+            bleu: {
+                prixKwhHP: 28.16,
+                prixKwhHC: 20.47
+            },
+            weekend: {
+                prixKwhHP: 20.47,
+                prixKwhHC: 20.47
+            }
+        },
+        {
+            puissance: 36,
+            abonnement: 46.08,
+            bleu: {
+                prixKwhHP: 28.16,
+                prixKwhHC: 20.47
+            },
+            weekend: {
+                prixKwhHP: 20.47,
+                prixKwhHC: 20.47
+            }
+        }],
+    hc: [{
+        start: { hour: 22, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    },
+    {
+        start: { hour: 0, minute: 0 },
+        end: { hour: 6, minute: 0 }
+    }],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [0, 6],
+    getDayType: function (day) {
+        let dayType = "bleu";
+
+        const isoDate = new Date(day.date);
+        const dayOfWeek = isoDate.getDay();
+
+        if (this.specialDays.includes(dayOfWeek)) {
+            dayType = "weekend";
+        }
+
+        return dayType;
+    }
+});

--- a/scripts/tarifs/edf/vertWeekEndHC.js
+++ b/scripts/tarifs/edf/vertWeekEndHC.js
@@ -92,7 +92,7 @@ abonnements.push({
         },
         {
             puissance: 36,
-            abonnement: 46.08,
+            abonnement: 45.08,
             bleu: {
                 prixKwhHP: 28.16,
                 prixKwhHC: 20.47

--- a/scripts/tarifs/edf/vertWeekEndHC.js
+++ b/scripts/tarifs/edf/vertWeekEndHC.js
@@ -102,14 +102,7 @@ abonnements.push({
                 prixKwhHC: 20.47
             }
         }],
-    hc: [{
-        start: { hour: 22, minute: 0 },
-        end: { hour: 24, minute: 0 }
-    },
-    {
-        start: { hour: 0, minute: 0 },
-        end: { hour: 6, minute: 0 }
-    }],
+    hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [0, 6],


### PR DESCRIPTION
Ajout des offres EDF Vert Électrique manquantes :
- Vert Elec Auto
- Vert Elec Régional (base et HPHC)
- Vert Elec Week-End (base et HPHC) 