### PR TITLE
Mise à jour EDF Zen Fixe au 2025-02-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Un outil pour simuler les différents tarifs de fournisseurs d'électricité dep
 [Version en ligne: https://comparateur-abonnements-electricite.fr](https://comparateur-abonnements-electricite.fr)
 
 ## Derniers tarifs: 
-* EDF : 2024-11-01
+* EDF : 2025-02-01
 * Alpiq : 01 Février 2024
 * Alterna : 01 Février 2024
 * ~~Ekwateur : 30 janvier 2024~~

--- a/scripts/tarifs/edf/zenFixe.js
+++ b/scripts/tarifs/edf/zenFixe.js
@@ -8,65 +8,65 @@ abonnements.push(
         price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",
         prices: [{
             puissance: 3,
-            abonnement: 9.69,
+            abonnement: 10.49,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 6,
-            abonnement: 12.67,
+            abonnement: 14.07,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 9,
-            abonnement: 15.89,
+            abonnement: 18.47,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 12,
-            abonnement: 19.16,
+            abonnement: 22.66,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 15,
-            abonnement: 22.21,
+            abonnement: 26.22,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 18,
-            abonnement: 25.24,
+            abonnement: 30.00,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 24,
-            abonnement: 31.96,
+            abonnement: 38.71,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 30,
-            abonnement: 37.68,
+            abonnement: 45.18,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 36,
-            abonnement: 44.43,
+            abonnement: 53.06,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         }],
         hc: [{

--- a/scripts/tarifs/edf/zenFixe.js
+++ b/scripts/tarifs/edf/zenFixe.js
@@ -2,7 +2,7 @@ abonnements.push(
     {
         name: "EDF - Zen Fixe",
         offer_type: "Marché",
-        lastUpdate: "2025-01-01",
+        lastUpdate: "2025-02-01",
         isCommunity: false,
         subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",
         price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",

--- a/scripts/tarifs/edf/zenFixeHC.js
+++ b/scripts/tarifs/edf/zenFixeHC.js
@@ -1,73 +1,73 @@
 abonnements.push({
     name: "EDF - Zen Fixe Heures Creuses",
     offer_type: "Marché",
-    lastUpdate: "2025-01-01",
+    lastUpdate: "2025-02-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",
     prices: [
         {
             puissance: 6,
-            abonnement: 13.09,
+            abonnement: 15.02,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 9,
-            abonnement: 16.82,
+            abonnement: 19.97,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 12,
-            abonnement: 20.28,
+            abonnement: 24.34,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 15,
-            abonnement: 23.09,
+            abonnement: 27.64,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 18,
-            abonnement: 26.26,
+            abonnement: 31.74,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 24,
-            abonnement: 32.92,
+            abonnement: 40.48,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 30,
-            abonnement: 38.97,
+            abonnement: 47.54,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 36,
-            abonnement: 45.08,
+            abonnement: 54.99,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         }],
     hc: [],


### PR DESCRIPTION
Les nouveaux tarifs sont dispos là https://particulier.edf.fr/content/dam/2-Actifs/Documents/Prix/Grille-prix-zen-fixe-01022025.pdf