### PR TITLE
Refactor prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Un outil pour simuler les différents tarifs de fournisseurs d'électricité dep
 [Version en ligne: https://comparateur-abonnements-electricite.fr](https://comparateur-abonnements-electricite.fr)
 
 ## Derniers tarifs: 
-* EDF : 2024-11-01
+* EDF : 2025-02-01
 * Alpiq : 01 Février 2024
 * Alterna : 01 Février 2024
 * ~~Ekwateur : 30 janvier 2024~~

--- a/scripts/tarifs/alpiq/base.js
+++ b/scripts/tarifs/alpiq/base.js
@@ -1,83 +1,30 @@
-abonnements.push(
-    {
-        name: "Alpiq - Base",
-        lastUpdate: "2024-11-26",
-        subscription_url: "https://particuliers.alpiq.fr/electricite/nos-tarifs",
-        price_url: "https://particuliers.alpiq.fr/grille-tarifaire/particuliers/gtr_elec_part.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 19.2766
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.68,
-            bleu: {
-                prixKwhHC: 19.2766
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.89,
-            bleu: {
-                prixKwhHC: 19.2766
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.16,
-            bleu: {
-                prixKwhHC: 19.2766
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.07,
-            bleu: {
-                prixKwhHC: 19.2766
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.24,
-            bleu: {
-                prixKwhHC: 19.2766
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.96,
-            bleu: {
-                prixKwhHC: 19.2766
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.68,
-            bleu: {
-                prixKwhHC: 19.2766
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.43,
-            bleu: {
-                prixKwhHC: 19.2766
-            }
-        }],
-        hc: [{
-            start: {hour:0, minute:0},
-            end: {hour:24, minute:0}
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "Alpiq - Base",
+    lastUpdate: "2024-11-26",
+    subscription_url: "https://particuliers.alpiq.fr/electricite/nos-tarifs",
+    price_url: "https://particuliers.alpiq.fr/grille-tarifaire/particuliers/gtr_elec_part.pdf",
+    prices: [
+        { puissance: 3, abonnement: 9.69 },
+        { puissance: 6, abonnement: 12.68 },
+        { puissance: 9, abonnement: 15.89 },
+        { puissance: 12, abonnement: 19.16 },
+        { puissance: 15, abonnement: 22.07 },
+        { puissance: 18, abonnement: 25.24 },
+        { puissance: 24, abonnement: 31.96 },
+        { puissance: 30, abonnement: 37.68 },
+        { puissance: 36, abonnement: 44.43 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 19.2766 }
+    })),
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/alpiq/hc.js
+++ b/scripts/tarifs/alpiq/hc.js
@@ -1,80 +1,26 @@
-abonnements.push(
-    {
-        name: "Alpiq - Heures Creuses",
-        lastUpdate: "2024-11-26",
-        subscription_url: "https://particuliers.alpiq.fr/electricite/nos-tarifs",
-        price_url: "https://particuliers.alpiq.fr/grille-tarifaire/particuliers/gtr_elec_part.pdf",
-        prices: [
-            {
-                puissance: 6,
-                abonnement: 13.09,
-                bleu: {
-                    prixKwhHP: 20.6352,
-                    prixKwhHC: 15.9554
-                }
-            },
-            {
-                puissance: 9,
-                abonnement: 16.70,
-                bleu: {
-                    prixKwhHP: 20.6352,
-                    prixKwhHC: 15.9554
-                }
-            },
-            {
-                puissance: 12,
-                abonnement: 20.28,
-                bleu: {
-                    prixKwhHP: 20.6352,
-                    prixKwhHC: 15.9554
-                }
-            },
-            {
-                puissance: 15,
-                abonnement: 23.57,
-                bleu: {
-                    prixKwhHP: 20.6352,
-                    prixKwhHC: 15.9554
-                }
-            },
-            {
-                puissance: 18,
-                abonnement: 26.84,
-                bleu: {
-                    prixKwhHP: 20.6352,
-                    prixKwhHC: 15.9554
-                }
-            },
-            {
-                puissance: 24,
-                abonnement: 33.70,
-                bleu: {
-                    prixKwhHP: 20.6352,
-                    prixKwhHC: 15.9554
-                }
-            },
-            {
-                puissance: 30,
-                abonnement: 38.97,
-                bleu: {
-                    prixKwhHP: 20.6352,
-                    prixKwhHC: 15.9554
-                }
-            },
-            {
-                puissance: 36,
-                abonnement: 45.08,
-                bleu: {
-                    prixKwhHP: 20.6352,
-                    prixKwhHC: 15.9554
-                }
-            }],
-        hc: [],
-        hasHCCustom: true,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
-    });
+abonnements.push({
+    name: "Alpiq - Heures Creuses",
+    lastUpdate: "2024-11-26",
+    subscription_url: "https://particuliers.alpiq.fr/electricite/nos-tarifs",
+    price_url: "https://particuliers.alpiq.fr/grille-tarifaire/particuliers/gtr_elec_part.pdf",
+    prices: [
+        { puissance: 6, abonnement: 13.09 },
+        { puissance: 9, abonnement: 16.70 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.57 },
+        { puissance: 18, abonnement: 26.84 },
+        { puissance: 24, abonnement: 33.70 },
+        { puissance: 30, abonnement: 38.97 },
+        { puissance: 36, abonnement: 45.08 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 20.6352, prixKwhHC: 15.9554 }
+    })),
+    hc: [],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
+    }
+});

--- a/scripts/tarifs/alterna/baseHC_france.js
+++ b/scripts/tarifs/alterna/baseHC_france.js
@@ -5,76 +5,23 @@ abonnements.push({
     subscription_url: "https://www.alterna-energie.fr",
     price_url: "https://www.alterna-energie.fr/tarifs-electricite-francaise",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.19,
-            bleu: {
-                prixKwhHP: 27.24,
-                prixKwhHC: 20.86
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.70,
-            bleu: {
-                prixKwhHP: 27.24,
-                prixKwhHC: 20.86
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.13,
-            bleu: {
-                prixKwhHP: 27.24,
-                prixKwhHC: 20.86
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.40,
-            bleu: {
-                prixKwhHP: 27.24,
-                prixKwhHC: 20.86
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.64,
-            bleu: {
-                prixKwhHP: 27.24,
-                prixKwhHC: 20.86
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.44,
-            bleu: {
-                prixKwhHP: 27.24,
-                prixKwhHC: 20.86
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.63,
-            bleu: {
-                prixKwhHP: 27.24,
-                prixKwhHC: 20.86
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.88,
-            bleu: {
-                prixKwhHP: 27.24,
-                prixKwhHC: 20.86
-            }
-        }],
+        { puissance: 6, abonnement: 13.19 },
+        { puissance: 9, abonnement: 16.70 },
+        { puissance: 12, abonnement: 20.13 },
+        { puissance: 15, abonnement: 23.40 },
+        { puissance: 18, abonnement: 26.64 },
+        { puissance: 24, abonnement: 33.44 },
+        { puissance: 30, abonnement: 39.63 },
+        { puissance: 36, abonnement: 45.88 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 27.24, prixKwhHC: 20.86 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/alterna/baseHC_local.js
+++ b/scripts/tarifs/alterna/baseHC_local.js
@@ -5,76 +5,23 @@ abonnements.push({
     subscription_url: "https://www.alterna-energie.fr",
     price_url: "https://www.alterna-energie.fr/tarifs-electricite-locale",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 14.32,
-            bleu: {
-                prixKwhHP: 24.06,
-                prixKwhHC: 18.49
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 18.12,
-            bleu: {
-                prixKwhHP: 24.06,
-                prixKwhHC: 18.49
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 21.83,
-            bleu: {
-                prixKwhHP: 24.06,
-                prixKwhHC: 18.49
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 25.37,
-            bleu: {
-                prixKwhHP: 24.06,
-                prixKwhHC: 18.49
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 28.87,
-            bleu: {
-                prixKwhHP: 24.06,
-                prixKwhHC: 18.49
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 36.23,
-            bleu: {
-                prixKwhHP: 24.06,
-                prixKwhHC: 18.49
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 42.92,
-            bleu: {
-                prixKwhHP: 24.06,
-                prixKwhHC: 18.49
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 49.66,
-            bleu: {
-                prixKwhHP: 24.06,
-                prixKwhHC: 18.49
-            }
-        }],
+        { puissance: 6, abonnement: 14.32 },
+        { puissance: 9, abonnement: 18.12 },
+        { puissance: 12, abonnement: 21.83 },
+        { puissance: 15, abonnement: 25.37 },
+        { puissance: 18, abonnement: 28.87 },
+        { puissance: 24, abonnement: 36.23 },
+        { puissance: 30, abonnement: 42.92 },
+        { puissance: 36, abonnement: 49.66 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 24.06, prixKwhHC: 18.49 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/alterna/base_france.js
+++ b/scripts/tarifs/alterna/base_france.js
@@ -1,84 +1,31 @@
-abonnements.push(
-    {
-        name: "Alterna - Base France",
-        offer_type: "Marché",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://www.alterna-energie.fr",
-        price_url: "https://www.alterna-energie.fr/tarifs-electricite-francaise",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 25.39
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.78,
-            bleu: {
-                prixKwhHC: 25.39
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.06,
-            bleu: {
-                prixKwhHC: 25.39
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.40,
-            bleu: {
-                prixKwhHC: 25.39
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.53,
-            bleu: {
-                prixKwhHC: 25.39
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.63,
-            bleu: {
-                prixKwhHC: 25.39
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.48,
-            bleu: {
-                prixKwhHC: 25.39
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.35,
-            bleu: {
-                prixKwhHC: 25.39
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.23,
-            bleu: {
-                prixKwhHC: 25.39
-            }
-        }],
-        hc: [{
-            start: {hour:0, minute:0},
-            end: {hour:24, minute:0}
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "Alterna - Base France",
+    offer_type: "Marché",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://www.alterna-energie.fr",
+    price_url: "https://www.alterna-energie.fr/tarifs-electricite-francaise",
+    prices: [
+        { puissance: 3, abonnement: 9.69 },
+        { puissance: 6, abonnement: 12.78 },
+        { puissance: 9, abonnement: 16.06 },
+        { puissance: 12, abonnement: 19.40 },
+        { puissance: 15, abonnement: 22.53 },
+        { puissance: 18, abonnement: 25.63 },
+        { puissance: 24, abonnement: 32.48 },
+        { puissance: 30, abonnement: 38.35 },
+        { puissance: 36, abonnement: 45.23 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 25.39 }
+    })),
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/alterna/base_local.js
+++ b/scripts/tarifs/alterna/base_local.js
@@ -1,84 +1,31 @@
-abonnements.push(
-    {
-        name: "Alterna - Base Locale",
-        offer_type: "Marché",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://www.alterna-energie.fr",
-        price_url: "https://www.alterna-energie.fr/tarifs-electricite-locale",
-        prices: [{
-            puissance: 3,
-            abonnement: 10.53,
-            bleu: {
-                prixKwhHC: 22.45
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 13.87,
-            bleu: {
-                prixKwhHC: 22.45
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 17.42,
-            bleu: {
-                prixKwhHC: 22.45
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 21.03,
-            bleu: {
-                prixKwhHC: 22.45
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 24.40,
-            bleu: {
-                prixKwhHC: 22.45
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 27.75,
-            bleu: {
-                prixKwhHC: 22.45
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 35.17,
-            bleu: {
-                prixKwhHC: 22.45
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 41.50,
-            bleu: {
-                prixKwhHC: 22.45
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 48.95,
-            bleu: {
-                prixKwhHC: 22.45
-            }
-        }],
-        hc: [{
-            start: {hour:0, minute:0},
-            end: {hour:24, minute:0}
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "Alterna - Base Locale",
+    offer_type: "Marché",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://www.alterna-energie.fr",
+    price_url: "https://www.alterna-energie.fr/tarifs-electricite-locale",
+    prices: [
+        { puissance: 3, abonnement: 10.53 },
+        { puissance: 6, abonnement: 13.87 },
+        { puissance: 9, abonnement: 17.42 },
+        { puissance: 12, abonnement: 21.03 },
+        { puissance: 15, abonnement: 24.40 },
+        { puissance: 18, abonnement: 27.75 },
+        { puissance: 24, abonnement: 35.17 },
+        { puissance: 30, abonnement: 41.50 },
+        { puissance: 36, abonnement: 48.95 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 22.45 }
+    })),
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/edf/bleu.js
+++ b/scripts/tarifs/edf/bleu.js
@@ -1,85 +1,32 @@
-abonnements.push(
-    {
-        name: "EDF - Bleu",
-        offer_type: "TRV",
-        lastUpdate: "2024-11-01",
-        isCommunity: false,
-        subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/tarif-bleu.html",
-        price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_Tarif_Bleu.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.68,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.89,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.16,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.07,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.24,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.96,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.68,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.43,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        }],
-        hc: [{
-            start: { hour: 0, minute: 0 },
-            end: { hour: 24, minute: 0 }
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "EDF - Bleu",
+    offer_type: "TRV",
+    lastUpdate: "2024-11-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/tarif-bleu.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_Tarif_Bleu.pdf",
+    prices: [
+        { puissance: 3, abonnement: 9.69 },
+        { puissance: 6, abonnement: 12.68 },
+        { puissance: 9, abonnement: 15.89 },
+        { puissance: 12, abonnement: 19.16 },
+        { puissance: 15, abonnement: 22.07 },
+        { puissance: 18, abonnement: 25.24 },
+        { puissance: 24, abonnement: 31.96 },
+        { puissance: 30, abonnement: 37.68 },
+        { puissance: 36, abonnement: 44.43 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 25.16 }
+    })),
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/edf/bleuHC.js
+++ b/scripts/tarifs/edf/bleuHC.js
@@ -1,82 +1,28 @@
-abonnements.push(
-    {
-        name: "EDF - Bleu Heures Creuses",
-        offer_type: "TRV",
-        lastUpdate: "2024-11-01",
-        isCommunity: false,
-        subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/tarif-bleu.html",
-        price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_Tarif_Bleu.pdf",
-        prices: [
-            {
-                puissance: 6,
-                abonnement: 13.09,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 9,
-                abonnement: 16.70,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 12,
-                abonnement: 20.28,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 15,
-                abonnement: 23.57,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 18,
-                abonnement: 26.84,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 24,
-                abonnement: 33.70,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 30,
-                abonnement: 38.97,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 36,
-                abonnement: 45.08,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            }],
-        hc: [],
-        hasHCCustom: true,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
-    });
+abonnements.push({
+    name: "EDF - Bleu Heures Creuses",
+    offer_type: "TRV",
+    lastUpdate: "2024-11-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/tarif-bleu.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_Tarif_Bleu.pdf",
+    prices: [
+        { puissance: 6, abonnement: 13.09 },
+        { puissance: 9, abonnement: 16.70 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.57 },
+        { puissance: 18, abonnement: 26.84 },
+        { puissance: 24, abonnement: 33.70 },
+        { puissance: 30, abonnement: 38.97 },
+        { puissance: 36, abonnement: 45.08 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 27.00, prixKwhHC: 20.68 }
+    })),
+    hc: [],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
+    }
+});

--- a/scripts/tarifs/edf/ejp.js
+++ b/scripts/tarifs/edf/ejp.js
@@ -6,66 +6,16 @@ abonnements.push({
     subscription_url: "",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_EJP.pdf",
     prices: [
-        {
-            puissance: 9,
-            abonnement: 15.90,
-            bleu: {
-                prixKwhHP: 17.58,
-                prixKwhHC: 17.58
-            },
-            rouge: {
-                prixKwhHP: 151.97,
-                prixKwhHC: 17.58
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 18.87,
-            bleu: {
-                prixKwhHP: 17.58,
-                prixKwhHC: 17.58
-            },
-            rouge: {
-                prixKwhHP: 151.97,
-                prixKwhHC: 17.58
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 21.92,
-            bleu: {
-                prixKwhHP: 17.58,
-                prixKwhHC: 17.58
-            },
-            rouge: {
-                prixKwhHP: 151.97,
-                prixKwhHC: 17.58
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 24.86,
-            bleu: {
-                prixKwhHP: 17.58,
-                prixKwhHC: 17.58
-            },
-            rouge: {
-                prixKwhHP: 151.97,
-                prixKwhHC: 17.58
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 43.41,
-            bleu: {
-                prixKwhHP: 17.58,
-                prixKwhHC: 17.58
-            },
-            rouge: {
-                prixKwhHP: 151.97,
-                prixKwhHC: 17.58
-            }
-        }],
+        { puissance: 9, abonnement: 15.90 },
+        { puissance: 12, abonnement: 18.87 },
+        { puissance: 15, abonnement: 21.92 },
+        { puissance: 18, abonnement: 24.86 },
+        { puissance: 36, abonnement: 43.41 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 17.58, prixKwhHC: 17.58 },
+        rouge: { prixKwhHP: 151.97, prixKwhHC: 17.58 }
+    })),
     hc: [{
         start: { hour: 1, minute: 0 },
         end: { hour: 7, minute: 0 }

--- a/scripts/tarifs/edf/tempo.js
+++ b/scripts/tarifs/edf/tempo.js
@@ -6,118 +6,19 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/gestion-contrat/options/tempo/details.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_Tarif_Bleu.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.03,
-            bleu: {
-                prixKwhHP: 16.09,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.94,
-                prixKwhHC: 14.86
-            },
-            rouge: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 15.68
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.25,
-            bleu: {
-                prixKwhHP: 16.09,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.94,
-                prixKwhHC: 14.86
-            },
-            rouge: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 15.68
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.56,
-            bleu: {
-                prixKwhHP: 16.09,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.94,
-                prixKwhHC: 14.86
-            },
-            rouge: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 15.68
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.45,
-            bleu: {
-                prixKwhHP: 16.09,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.94,
-                prixKwhHC: 14.86
-            },
-            rouge: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 15.68
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.60,
-            bleu: {
-                prixKwhHP: 16.09,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.94,
-                prixKwhHC: 14.86
-            },
-            rouge: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 15.68
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.53,
-            bleu: {
-                prixKwhHP: 16.09,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.94,
-                prixKwhHC: 14.86
-            },
-            rouge: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 15.68
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.71,
-            bleu: {
-                prixKwhHP: 16.09,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.94,
-                prixKwhHC: 14.86
-            },
-            rouge: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 15.68
-            }
-        }],
+        { puissance: 6, abonnement: 13.03 },
+        { puissance: 9, abonnement: 16.25 },
+        { puissance: 12, abonnement: 19.56 },
+        { puissance: 15, abonnement: 22.45 },
+        { puissance: 18, abonnement: 25.60 },
+        { puissance: 30, abonnement: 38.53 },
+        { puissance: 36, abonnement: 44.71 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 16.09, prixKwhHC: 12.96 },
+        blanc: { prixKwhHP: 18.94, prixKwhHC: 14.86 },
+        rouge: { prixKwhHP: 75.62, prixKwhHC: 15.68 }
+    })),
     hc: [{
         start: { hour: 22, minute: 0 },
         end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/edf/vert.js
+++ b/scripts/tarifs/edf/vert.js
@@ -1,85 +1,32 @@
-abonnements.push(
-    {
-        name: "EDF - Vert Electrique",
-        offer_type: "Marché",
-        lastUpdate: "2024-11-01",
-        isCommunity: false,
-        subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique.html",
-        price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 24.23
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.68,
-            bleu: {
-                prixKwhHC: 24.23
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.89,
-            bleu: {
-                prixKwhHC: 24.23
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.16,
-            bleu: {
-                prixKwhHC: 24.23
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.21,
-            bleu: {
-                prixKwhHC: 24.23
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.24,
-            bleu: {
-                prixKwhHC: 24.23
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.96,
-            bleu: {
-                prixKwhHC: 24.23
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.68,
-            bleu: {
-                prixKwhHC: 24.23
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.43,
-            bleu: {
-                prixKwhHC: 24.23
-            }
-        }],
-        hc: [{
-            start: { hour: 0, minute: 0 },
-            end: { hour: 24, minute: 0 }
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "EDF - Vert Electrique",
+    offer_type: "Marché",
+    lastUpdate: "2024-11-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique.pdf",
+    prices: [
+        { puissance: 3, abonnement: 9.69 },
+        { puissance: 6, abonnement: 12.68 },
+        { puissance: 9, abonnement: 15.89 },
+        { puissance: 12, abonnement: 19.16 },
+        { puissance: 15, abonnement: 22.21 },
+        { puissance: 18, abonnement: 25.24 },
+        { puissance: 24, abonnement: 31.96 },
+        { puissance: 30, abonnement: 37.68 },
+        { puissance: 36, abonnement: 44.43 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 24.23 }
+    })),
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/edf/vertAuto.js
+++ b/scripts/tarifs/edf/vertAuto.js
@@ -6,76 +6,23 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-auto.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-auto.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.28,
-            bleu: {
-                prixKwhHP: 29.53,
-                prixKwhHC: 16.03
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.82,
-            bleu: {
-                prixKwhHP: 29.53,
-                prixKwhHC: 16.03
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.28,
-            bleu: {
-                prixKwhHP: 29.53,
-                prixKwhHC: 16.03
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.57,
-            bleu: {
-                prixKwhHP: 29.53,
-                prixKwhHC: 16.03
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.84,
-            bleu: {
-                prixKwhHP: 29.53,
-                prixKwhHC: 16.03
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.70,
-            bleu: {
-                prixKwhHP: 29.53,
-                prixKwhHC: 16.03
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.94,
-            bleu: {
-                prixKwhHP: 29.53,
-                prixKwhHC: 16.03
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.08,
-            bleu: {
-                prixKwhHP: 29.53,
-                prixKwhHC: 16.03
-            }
-        }],
+        { puissance: 6, abonnement: 13.28 },
+        { puissance: 9, abonnement: 16.82 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.57 },
+        { puissance: 18, abonnement: 26.84 },
+        { puissance: 24, abonnement: 33.70 },
+        { puissance: 30, abonnement: 39.94 },
+        { puissance: 36, abonnement: 45.08 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 29.53, prixKwhHC: 16.03 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/edf/vertHC.js
+++ b/scripts/tarifs/edf/vertHC.js
@@ -6,76 +6,23 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.09,
-            bleu: {
-                prixKwhHP: 26.18,
-                prixKwhHC: 19.86
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.82,
-            bleu: {
-                prixKwhHP: 26.18,
-                prixKwhHC: 19.86
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.28,
-            bleu: {
-                prixKwhHP: 26.18,
-                prixKwhHC: 19.86
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.09,
-            bleu: {
-                prixKwhHP: 26.18,
-                prixKwhHC: 19.86
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.26,
-            bleu: {
-                prixKwhHP: 26.18,
-                prixKwhHC: 19.86
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.92,
-            bleu: {
-                prixKwhHP: 26.18,
-                prixKwhHC: 19.86
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.97,
-            bleu: {
-                prixKwhHP: 26.18,
-                prixKwhHC: 19.86
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.08,
-            bleu: {
-                prixKwhHP: 26.18,
-                prixKwhHC: 19.86
-            }
-        }],
+        { puissance: 6, abonnement: 13.09 },
+        { puissance: 9, abonnement: 16.82 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.09 },
+        { puissance: 18, abonnement: 26.26 },
+        { puissance: 24, abonnement: 32.92 },
+        { puissance: 30, abonnement: 38.97 },
+        { puissance: 36, abonnement: 45.08 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 26.18, prixKwhHC: 19.86 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/edf/vertRegional.js
+++ b/scripts/tarifs/edf/vertRegional.js
@@ -6,62 +6,19 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-regional.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-regional.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 12.68,
-            bleu: {
-                prixKwhHC: 24.84
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.89,
-            bleu: {
-                prixKwhHC: 24.88
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.16,
-            bleu: {
-                prixKwhHC: 24.88
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.21,
-            bleu: {
-                prixKwhHC: 24.88
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.24,
-            bleu: {
-                prixKwhHC: 24.88
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.96,
-            bleu: {
-                prixKwhHC: 24.88
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.68,
-            bleu: {
-                prixKwhHC: 24.88
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.60,
-            bleu: {
-                prixKwhHC: 24.88
-            }
-        }],
+        { puissance: 6, abonnement: 12.68, prixKwhHC: 24.84 },
+        { puissance: 9, abonnement: 15.89, prixKwhHC: 24.88 },
+        { puissance: 12, abonnement: 19.16, prixKwhHC: 24.88 },
+        { puissance: 15, abonnement: 22.21, prixKwhHC: 24.88 },
+        { puissance: 18, abonnement: 25.24, prixKwhHC: 24.88 },
+        { puissance: 24, abonnement: 31.96, prixKwhHC: 24.88 },
+        { puissance: 30, abonnement: 37.68, prixKwhHC: 24.88 },
+        { puissance: 36, abonnement: 45.60, prixKwhHC: 24.88 }
+    ].map(item => ({
+        puissance: item.puissance,
+        abonnement: item.abonnement,
+        bleu: { prixKwhHC: item.prixKwhHC }
+    })),
     hc: [{
         start: { hour: 0, minute: 0 },
         end: { hour: 24, minute: 0 }
@@ -70,7 +27,6 @@ abonnements.push({
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/edf/vertRegionalHC.js
+++ b/scripts/tarifs/edf/vertRegionalHC.js
@@ -6,76 +6,23 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-regional.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-regional.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.09,
-            bleu: {
-                prixKwhHP: 27.70,
-                prixKwhHC: 19.03
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.82,
-            bleu: {
-                prixKwhHP: 27.70,
-                prixKwhHC: 19.03
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.28,
-            bleu: {
-                prixKwhHP: 27.70,
-                prixKwhHC: 19.03
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.57,
-            bleu: {
-                prixKwhHP: 27.70,
-                prixKwhHC: 19.03
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.26,
-            bleu: {
-                prixKwhHP: 27.70,
-                prixKwhHC: 19.03
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.92,
-            bleu: {
-                prixKwhHP: 27.70,
-                prixKwhHC: 19.03
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.97,
-            bleu: {
-                prixKwhHP: 27.70,
-                prixKwhHC: 19.03
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.08,
-            bleu: {
-                prixKwhHP: 27.70,
-                prixKwhHC: 19.03
-            }
-        }],
+        { puissance: 6, abonnement: 13.09 },
+        { puissance: 9, abonnement: 16.82 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.57 },
+        { puissance: 18, abonnement: 26.26 },
+        { puissance: 24, abonnement: 32.92 },
+        { puissance: 30, abonnement: 38.97 },
+        { puissance: 36, abonnement: 45.08 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 27.70, prixKwhHC: 19.03 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/edf/vertWeekEnd.js
+++ b/scripts/tarifs/edf/vertWeekEnd.js
@@ -6,86 +6,19 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-weekend.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 12.68,
-            bleu: {
-                prixKwhHC: 26.58
-            },
-            weekend: {
-                prixKwhHC: 19.37
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.89,
-            bleu: {
-                prixKwhHC: 26.58
-            },
-            weekend: {
-                prixKwhHC: 19.37
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.16,
-            bleu: {
-                prixKwhHC: 26.58
-            },
-            weekend: {
-                prixKwhHC: 19.37
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.21,
-            bleu: {
-                prixKwhHC: 26.58
-            },
-            weekend: {
-                prixKwhHC: 19.37
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.24,
-            bleu: {
-                prixKwhHC: 26.58
-            },
-            weekend: {
-                prixKwhHC: 19.37
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.96,
-            bleu: {
-                prixKwhHC: 26.58
-            },
-            weekend: {
-                prixKwhHC: 19.37
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.66,
-            bleu: {
-                prixKwhHC: 26.58
-            },
-            weekend: {
-                prixKwhHC: 19.37
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.43,
-            bleu: {
-                prixKwhHC: 26.58
-            },
-            weekend: {
-                prixKwhHC: 19.37
-            }
-        }],
+        { puissance: 6, abonnement: 12.68 },
+        { puissance: 9, abonnement: 15.89 },
+        { puissance: 12, abonnement: 19.16 },
+        { puissance: 15, abonnement: 22.21 },
+        { puissance: 18, abonnement: 25.24 },
+        { puissance: 24, abonnement: 31.96 },
+        { puissance: 30, abonnement: 38.66 },
+        { puissance: 36, abonnement: 44.43 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 26.58 },
+        weekend: { prixKwhHC: 19.37 }
+    })),
     hc: [{
         start: { hour: 0, minute: 0 },
         end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/edf/vertWeekEndHC.js
+++ b/scripts/tarifs/edf/vertWeekEndHC.js
@@ -6,102 +6,19 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-weekend.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.09,
-            bleu: {
-                prixKwhHP: 28.16,
-                prixKwhHC: 20.47
-            },
-            weekend: {
-                prixKwhHP: 20.47,
-                prixKwhHC: 20.47
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.82,
-            bleu: {
-                prixKwhHP: 28.16,
-                prixKwhHC: 20.47
-            },
-            weekend: {
-                prixKwhHP: 20.47,
-                prixKwhHC: 20.47
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.28,
-            bleu: {
-                prixKwhHP: 28.16,
-                prixKwhHC: 20.47
-            },
-            weekend: {
-                prixKwhHP: 20.47,
-                prixKwhHC: 20.47
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.57,
-            bleu: {
-                prixKwhHP: 28.16,
-                prixKwhHC: 20.47
-            },
-            weekend: {
-                prixKwhHP: 20.47,
-                prixKwhHC: 20.47
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.84,
-            bleu: {
-                prixKwhHP: 28.16,
-                prixKwhHC: 20.47
-            },
-            weekend: {
-                prixKwhHP: 20.47,
-                prixKwhHC: 20.47
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.70,
-            bleu: {
-                prixKwhHP: 28.16,
-                prixKwhHC: 20.47
-            },
-            weekend: {
-                prixKwhHP: 20.47,
-                prixKwhHC: 20.47
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.94,
-            bleu: {
-                prixKwhHP: 28.16,
-                prixKwhHC: 20.47
-            },
-            weekend: {
-                prixKwhHP: 20.47,
-                prixKwhHC: 20.47
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.08,
-            bleu: {
-                prixKwhHP: 28.16,
-                prixKwhHC: 20.47
-            },
-            weekend: {
-                prixKwhHP: 20.47,
-                prixKwhHC: 20.47
-            }
-        }],
+        { puissance: 6, abonnement: 13.09 },
+        { puissance: 9, abonnement: 16.82 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.57 },
+        { puissance: 18, abonnement: 26.84 },
+        { puissance: 24, abonnement: 33.70 },
+        { puissance: 30, abonnement: 39.94 },
+        { puissance: 36, abonnement: 45.08 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 28.16, prixKwhHC: 20.47 },
+        weekend: { prixKwhHP: 20.47, prixKwhHC: 20.47 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,

--- a/scripts/tarifs/edf/zenFixe.js
+++ b/scripts/tarifs/edf/zenFixe.js
@@ -8,65 +8,65 @@ abonnements.push(
         price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",
         prices: [{
             puissance: 3,
-            abonnement: 9.69,
+            abonnement: 10.49,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 6,
-            abonnement: 12.67,
+            abonnement: 14.07,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 9,
-            abonnement: 15.89,
+            abonnement: 18.47,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 12,
-            abonnement: 19.16,
+            abonnement: 22.66,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 15,
-            abonnement: 22.21,
+            abonnement: 26.22,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 18,
-            abonnement: 25.24,
+            abonnement: 30.00,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 24,
-            abonnement: 31.96,
+            abonnement: 38.71,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 30,
-            abonnement: 37.68,
+            abonnement: 45.18,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         },
         {
             puissance: 36,
-            abonnement: 44.43,
+            abonnement: 53.06,
             bleu: {
-                prixKwhHC: 17.53
+                prixKwhHC: 19.06
             }
         }],
         hc: [{

--- a/scripts/tarifs/edf/zenFixe.js
+++ b/scripts/tarifs/edf/zenFixe.js
@@ -1,85 +1,32 @@
-abonnements.push(
-    {
-        name: "EDF - Zen Fixe",
-        offer_type: "Marché",
-        lastUpdate: "2025-02-01",
-        isCommunity: false,
-        subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",
-        price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 10.49,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 14.07,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 18.47,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 22.66,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 26.22,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 30.00,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 38.71,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 45.18,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 53.06,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        }],
-        hc: [{
-            start: { hour: 0, minute: 0 },
-            end: { hour: 24, minute: 0 }
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "EDF - Zen Fixe",
+    offer_type: "Marché",
+    lastUpdate: "2025-02-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",
+    prices: [
+        { puissance: 3, abonnement: 10.49 },
+        { puissance: 6, abonnement: 14.07 },
+        { puissance: 9, abonnement: 18.47 },
+        { puissance: 12, abonnement: 22.66 },
+        { puissance: 15, abonnement: 26.22 },
+        { puissance: 18, abonnement: 30.00 },
+        { puissance: 24, abonnement: 38.71 },
+        { puissance: 30, abonnement: 45.18 },
+        { puissance: 36, abonnement: 53.06 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 19.06 }
+    })),
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/edf/zenFixe.js
+++ b/scripts/tarifs/edf/zenFixe.js
@@ -2,7 +2,7 @@ abonnements.push(
     {
         name: "EDF - Zen Fixe",
         offer_type: "Marché",
-        lastUpdate: "2025-01-01",
+        lastUpdate: "2025-02-01",
         isCommunity: false,
         subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",
         price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",

--- a/scripts/tarifs/edf/zenFixeHC.js
+++ b/scripts/tarifs/edf/zenFixeHC.js
@@ -1,73 +1,73 @@
 abonnements.push({
     name: "EDF - Zen Fixe Heures Creuses",
     offer_type: "Marché",
-    lastUpdate: "2025-01-01",
+    lastUpdate: "2025-02-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",
     prices: [
         {
             puissance: 6,
-            abonnement: 13.09,
+            abonnement: 15.02,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 9,
-            abonnement: 16.82,
+            abonnement: 19.97,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 12,
-            abonnement: 20.28,
+            abonnement: 24.34,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 15,
-            abonnement: 23.09,
+            abonnement: 27.64,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 18,
-            abonnement: 26.26,
+            abonnement: 31.74,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 24,
-            abonnement: 32.92,
+            abonnement: 40.48,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 30,
-            abonnement: 38.97,
+            abonnement: 47.54,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         },
         {
             puissance: 36,
-            abonnement: 45.08,
+            abonnement: 54.99,
             bleu: {
-                prixKwhHP: 18.76,
-                prixKwhHC: 14.56
+                prixKwhHP: 20.28,
+                prixKwhHC: 16.08
             }
         }],
     hc: [],

--- a/scripts/tarifs/edf/zenFixeHC.js
+++ b/scripts/tarifs/edf/zenFixeHC.js
@@ -6,76 +6,23 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-fixe.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille-prix-zen-fixe.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 15.02,
-            bleu: {
-                prixKwhHP: 20.28,
-                prixKwhHC: 16.08
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 19.97,
-            bleu: {
-                prixKwhHP: 20.28,
-                prixKwhHC: 16.08
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 24.34,
-            bleu: {
-                prixKwhHP: 20.28,
-                prixKwhHC: 16.08
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 27.64,
-            bleu: {
-                prixKwhHP: 20.28,
-                prixKwhHC: 16.08
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 31.74,
-            bleu: {
-                prixKwhHP: 20.28,
-                prixKwhHC: 16.08
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 40.48,
-            bleu: {
-                prixKwhHP: 20.28,
-                prixKwhHC: 16.08
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 47.54,
-            bleu: {
-                prixKwhHP: 20.28,
-                prixKwhHC: 16.08
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 54.99,
-            bleu: {
-                prixKwhHP: 20.28,
-                prixKwhHC: 16.08
-            }
-        }],
+        { puissance: 6, abonnement: 15.02 },
+        { puissance: 9, abonnement: 19.97 },
+        { puissance: 12, abonnement: 24.34 },
+        { puissance: 15, abonnement: 27.64 },
+        { puissance: 18, abonnement: 31.74 },
+        { puissance: 24, abonnement: 40.48 },
+        { puissance: 30, abonnement: 47.54 },
+        { puissance: 36, abonnement: 54.99 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 20.28, prixKwhHC: 16.08 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/edf/zenFlex.js
+++ b/scripts/tarifs/edf/zenFlex.js
@@ -6,102 +6,19 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-flex.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.09,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 17.95
-            },
-            sobriete: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 27.00
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.82,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 17.95
-            },
-            sobriete: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 27.00
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.28,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 17.95
-            },
-            sobriete: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 27.00
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.57,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 17.95
-            },
-            sobriete: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 27.00
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.84,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 17.95
-            },
-            sobriete: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 27.00
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.70,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 17.95
-            },
-            sobriete: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 27.00
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.94,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 17.95
-            },
-            sobriete: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 27.00
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 46.24,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 17.95
-            },
-            sobriete: {
-                prixKwhHP: 75.62,
-                prixKwhHC: 27.00
-            }
-        }],
+        { puissance: 6, abonnement: 13.09 },
+        { puissance: 9, abonnement: 16.82 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.57 },
+        { puissance: 18, abonnement: 26.84 },
+        { puissance: 24, abonnement: 33.70 },
+        { puissance: 30, abonnement: 39.94 },
+        { puissance: 36, abonnement: 46.24 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 27.00, prixKwhHC: 17.95 },
+        sobriete: { prixKwhHP: 75.62, prixKwhHC: 27.00 }
+    })),
     hc: [{
         start: { hour: 0, minute: 0 },
         end: { hour: 8, minute: 0 }

--- a/scripts/tarifs/edf/zenOnline.js
+++ b/scripts/tarifs/edf/zenOnline.js
@@ -1,85 +1,32 @@
-abonnements.push(
-    {
-        name: "EDF - Zen Online",
-        offer_type: "Marché",
-        lastUpdate: "2024-12-01",
-        isCommunity: false,
-        subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-online.html",
-        price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-online.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 23.03
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.68,
-            bleu: {
-                prixKwhHC: 23.03
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.18,
-            bleu: {
-                prixKwhHC: 23.03
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.55,
-            bleu: {
-                prixKwhHC: 23.03
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.70,
-            bleu: {
-                prixKwhHC: 23.03
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.83,
-            bleu: {
-                prixKwhHC: 23.03
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.74,
-            bleu: {
-                prixKwhHC: 23.03
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.66,
-            bleu: {
-                prixKwhHC: 23.03
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.43,
-            bleu: {
-                prixKwhHC: 23.03
-            }
-        }],
-        hc: [{
-            start: { hour: 0, minute: 0 },
-            end: { hour: 24, minute: 0 }
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "EDF - Zen Online",
+    offer_type: "Marché",
+    lastUpdate: "2024-12-01",
+    isCommunity: false,
+    subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-online.html",
+    price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-online.pdf",
+    prices: [
+        { puissance: 3, abonnement: 9.69 },
+        { puissance: 6, abonnement: 12.68 },
+        { puissance: 9, abonnement: 16.18 },
+        { puissance: 12, abonnement: 19.55 },
+        { puissance: 15, abonnement: 22.70 },
+        { puissance: 18, abonnement: 25.83 },
+        { puissance: 24, abonnement: 32.74 },
+        { puissance: 30, abonnement: 38.66 },
+        { puissance: 36, abonnement: 44.43 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 23.03 }
+    })),
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/edf/zenOnlineHC.js
+++ b/scripts/tarifs/edf/zenOnlineHC.js
@@ -6,76 +6,23 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-online.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-online.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.09,
-            bleu: {
-                prixKwhHP: 24.70,
-                prixKwhHC: 18.96
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.82,
-            bleu: {
-                prixKwhHP: 24.70,
-                prixKwhHC: 18.96
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.28,
-            bleu: {
-                prixKwhHP: 24.70,
-                prixKwhHC: 18.96
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.57,
-            bleu: {
-                prixKwhHP: 24.70,
-                prixKwhHC: 18.96
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.84,
-            bleu: {
-                prixKwhHP: 24.70,
-                prixKwhHC: 18.96
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.92,
-            bleu: {
-                prixKwhHP: 24.70,
-                prixKwhHC: 18.96
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.97,
-            bleu: {
-                prixKwhHP: 24.70,
-                prixKwhHC: 18.96
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.08,
-            bleu: {
-                prixKwhHP: 24.70,
-                prixKwhHC: 18.96
-            }
-        }],
+        { puissance: 6, abonnement: 13.09 },
+        { puissance: 9, abonnement: 16.82 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.57 },
+        { puissance: 18, abonnement: 26.84 },
+        { puissance: 24, abonnement: 32.92 },
+        { puissance: 30, abonnement: 38.97 },
+        { puissance: 36, abonnement: 45.08 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 24.70, prixKwhHC: 18.96 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/edf/zenWeekEnd.js
+++ b/scripts/tarifs/edf/zenWeekEnd.js
@@ -7,96 +7,20 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end.pdf",
     prices: [
-        {
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 26.52
-            },
-            weekend: {
-                prixKwhHC: 19.32
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.68,
-            bleu: {
-                prixKwhHC: 26.52
-            },
-            weekend: {
-                prixKwhHC: 19.32
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.89,
-            bleu: {
-                prixKwhHC: 26.52
-            },
-            weekend: {
-                prixKwhHC: 19.32
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.32,
-            bleu: {
-                prixKwhHC: 26.52
-            },
-            weekend: {
-                prixKwhHC: 19.32
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.21,
-            bleu: {
-                prixKwhHC: 26.52
-            },
-            weekend: {
-                prixKwhHC: 19.32
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.24,
-            bleu: {
-                prixKwhHC: 26.52
-            },
-            weekend: {
-                prixKwhHC: 19.32
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.74,
-            bleu: {
-                prixKwhHC: 26.52
-            },
-            weekend: {
-                prixKwhHC: 19.32
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.68,
-            bleu: {
-                prixKwhHC: 26.52
-            },
-            weekend: {
-                prixKwhHC: 19.32
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.43,
-            bleu: {
-                prixKwhHC: 26.52
-            },
-            weekend: {
-                prixKwhHC: 19.32
-            }
-        }],
+        { puissance: 3, abonnement: 9.69 },
+        { puissance: 6, abonnement: 12.68 },
+        { puissance: 9, abonnement: 15.89 },
+        { puissance: 12, abonnement: 19.32 },
+        { puissance: 15, abonnement: 22.21 },
+        { puissance: 18, abonnement: 25.24 },
+        { puissance: 24, abonnement: 32.74 },
+        { puissance: 30, abonnement: 37.68 },
+        { puissance: 36, abonnement: 44.43 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 26.52 },
+        weekend: { prixKwhHC: 19.32 }
+    })),
     hc: [{
         start: { hour: 0, minute: 0 },
         end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/edf/zenWeekEndHC.js
+++ b/scripts/tarifs/edf/zenWeekEndHC.js
@@ -6,110 +6,23 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.09,
-            bleu: {
-                prixKwhHP: 28.08,
-                prixKwhHC: 20.41
-            },
-            weekend: {
-                prixKwhHP: 20.41,
-                prixKwhHC: 20.41
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.82,
-            bleu: {
-                prixKwhHP: 28.08,
-                prixKwhHC: 20.41
-            },
-            weekend: {
-                prixKwhHP: 20.41,
-                prixKwhHC: 20.41
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.28,
-            bleu: {
-                prixKwhHP: 28.08,
-                prixKwhHC: 20.41
-            },
-            weekend: {
-                prixKwhHP: 20.41,
-                prixKwhHC: 20.41
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.57,
-            bleu: {
-                prixKwhHP: 28.08,
-                prixKwhHC: 20.41
-            },
-            weekend: {
-                prixKwhHP: 20.41,
-                prixKwhHC: 20.41
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.84,
-            bleu: {
-                prixKwhHP: 28.08,
-                prixKwhHC: 20.41
-            },
-            weekend: {
-                prixKwhHP: 20.41,
-                prixKwhHC: 20.41
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.70,
-            bleu: {
-                prixKwhHP: 28.08,
-                prixKwhHC: 20.41
-            },
-            weekend: {
-                prixKwhHP: 20.41,
-                prixKwhHC: 20.41
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.94,
-            bleu: {
-                prixKwhHP: 28.08,
-                prixKwhHC: 20.41
-            },
-            weekend: {
-                prixKwhHP: 20.41,
-                prixKwhHC: 20.41
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 46.24,
-            bleu: {
-                prixKwhHP: 28.08,
-                prixKwhHC: 20.41
-            },
-            weekend: {
-                prixKwhHP: 20.41,
-                prixKwhHC: 20.41
-            }
-        }],
-    hc: [{
-        start: { hour: 22, minute: 0 },
-        end: { hour: 24, minute: 0 }
-    },
-    {
-        start: { hour: 0, minute: 0 },
-        end: { hour: 6, minute: 0 }
-    }],
+        { puissance: 6, abonnement: 13.09 },
+        { puissance: 9, abonnement: 16.82 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.57 },
+        { puissance: 18, abonnement: 26.84 },
+        { puissance: 24, abonnement: 33.70 },
+        { puissance: 30, abonnement: 39.94 },
+        { puissance: 36, abonnement: 46.24 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 28.08, prixKwhHC: 20.41 },
+        weekend: { prixKwhHP: 20.41, prixKwhHC: 20.41 }
+    })),
+    hc: [
+        { start: { hour: 22, minute: 0 }, end: { hour: 24, minute: 0 } },
+        { start: { hour: 0, minute: 0 }, end: { hour: 6, minute: 0 } }
+    ],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [0, 6],

--- a/scripts/tarifs/edf/zenWeekEndPlus.js
+++ b/scripts/tarifs/edf/zenWeekEndPlus.js
@@ -6,86 +6,19 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end-plus.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end-plus.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 12.68,
-            bleu: {
-                prixKwhHC: 27.78
-            },
-            weekend: {
-                prixKwhHC: 20.21
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.18,
-            bleu: {
-                prixKwhHC: 27.78
-            },
-            weekend: {
-                prixKwhHC: 20.21
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.55,
-            bleu: {
-                prixKwhHC: 27.78
-            },
-            weekend: {
-                prixKwhHC: 20.21
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.21,
-            bleu: {
-                prixKwhHC: 27.78
-            },
-            weekend: {
-                prixKwhHC: 20.21
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.24,
-            bleu: {
-                prixKwhHC: 27.78
-            },
-            weekend: {
-                prixKwhHC: 20.21
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.96,
-            bleu: {
-                prixKwhHC: 27.78
-            },
-            weekend: {
-                prixKwhHC: 20.21
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.68,
-            bleu: {
-                prixKwhHC: 27.78
-            },
-            weekend: {
-                prixKwhHC: 20.21
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.43,
-            bleu: {
-                prixKwhHC: 27.78
-            },
-            weekend: {
-                prixKwhHC: 20.21
-            }
-        }],
+        { puissance: 6, abonnement: 12.68 },
+        { puissance: 9, abonnement: 16.18 },
+        { puissance: 12, abonnement: 19.55 },
+        { puissance: 15, abonnement: 22.21 },
+        { puissance: 18, abonnement: 25.24 },
+        { puissance: 24, abonnement: 31.96 },
+        { puissance: 30, abonnement: 37.68 },
+        { puissance: 36, abonnement: 44.43 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 27.78 },
+        weekend: { prixKwhHC: 20.21 }
+    })),
     hc: [{
         start: { hour: 0, minute: 0 },
         end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/edf/zenWeekEndPlusHC.js
+++ b/scripts/tarifs/edf/zenWeekEndPlusHC.js
@@ -6,110 +6,23 @@ abonnements.push({
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end-plus.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end-plus.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.09,
-            bleu: {
-                prixKwhHP: 28.88,
-                prixKwhHC: 20.98
-            },
-            weekend: {
-                prixKwhHP: 20.98,
-                prixKwhHC: 20.98,
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.82,
-            bleu: {
-                prixKwhHP: 28.88,
-                prixKwhHC: 20.98
-            },
-            weekend: {
-                prixKwhHP: 20.98,
-                prixKwhHC: 20.98,
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.28,
-            bleu: {
-                prixKwhHP: 28.88,
-                prixKwhHC: 20.98
-            },
-            weekend: {
-                prixKwhHP: 20.98,
-                prixKwhHC: 20.98,
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.57,
-            bleu: {
-                prixKwhHP: 28.88,
-                prixKwhHC: 20.98
-            },
-            weekend: {
-                prixKwhHP: 20.98,
-                prixKwhHC: 20.98,
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.84,
-            bleu: {
-                prixKwhHP: 28.88,
-                prixKwhHC: 20.98
-            },
-            weekend: {
-                prixKwhHP: 20.98,
-                prixKwhHC: 20.98,
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.70,
-            bleu: {
-                prixKwhHP: 28.88,
-                prixKwhHC: 20.98
-            },
-            weekend: {
-                prixKwhHP: 20.98,
-                prixKwhHC: 20.98,
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.94,
-            bleu: {
-                prixKwhHP: 28.88,
-                prixKwhHC: 20.98
-            },
-            weekend: {
-                prixKwhHP: 20.98,
-                prixKwhHC: 20.98,
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 46.24,
-            bleu: {
-                prixKwhHP: 28.88,
-                prixKwhHC: 20.98
-            },
-            weekend: {
-                prixKwhHP: 20.98,
-                prixKwhHC: 20.98,
-            }
-        }],
-    hc: [{
-        start: { hour: 22, minute: 0 },
-        end: { hour: 24, minute: 0 }
-    },
-    {
-        start: { hour: 0, minute: 0 },
-        end: { hour: 6, minute: 0 }
-    }],
+        { puissance: 6, abonnement: 13.09 },
+        { puissance: 9, abonnement: 16.82 },
+        { puissance: 12, abonnement: 20.28 },
+        { puissance: 15, abonnement: 23.57 },
+        { puissance: 18, abonnement: 26.84 },
+        { puissance: 24, abonnement: 33.70 },
+        { puissance: 30, abonnement: 39.94 },
+        { puissance: 36, abonnement: 46.24 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 28.88, prixKwhHC: 20.98 },
+        weekend: { prixKwhHP: 20.98, prixKwhHC: 20.98 }
+    })),
+    hc: [
+        { start: { hour: 22, minute: 0 }, end: { hour: 24, minute: 0 } },
+        { start: { hour: 0, minute: 0 }, end: { hour: 6, minute: 0 } }
+    ],
     hasHCCustom: true,
     hasSpecialDaysCustom: true,
     specialDays: [0, 6],

--- a/scripts/tarifs/ekwateur/ElectriciteVerteFixe.js
+++ b/scripts/tarifs/ekwateur/ElectriciteVerteFixe.js
@@ -2,69 +2,20 @@ abonnements.push(
     {
         name: "Ekwateur - Electricité verte fixe",
         lastUpdate: "2024-01-30",
-        prices: [{
-            puissance: 3,
-            abonnement: 13.29,
-            bleu: {
-                prixKwhHC: 24.52
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 16.54,
-            bleu: {
-                prixKwhHC: 24.52
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 19.95,
-            bleu: {
-                prixKwhHC: 24.56
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 23.29,
-            bleu: {
-                prixKwhHC: 24.56
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 26.43,
-            bleu: {
-                prixKwhHC: 24.56
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 29.69,
-            bleu: {
-                prixKwhHC: 24.56
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 36.31,
-            bleu: {
-                prixKwhHC: 24.56
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 45.04,
-            bleu: {
-                prixKwhHC: 24.56
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 52.08,
-            bleu: {
-                prixKwhHC: 24.56
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 13.29 },
+    { puissance: 6, abonnement: 16.54 },
+    { puissance: 9, abonnement: 19.95 },
+    { puissance: 12, abonnement: 23.29 },
+    { puissance: 15, abonnement: 26.43 },
+    { puissance: 18, abonnement: 29.69 },
+    { puissance: 24, abonnement: 36.31 },
+    { puissance: 30, abonnement: 45.04 },
+    { puissance: 36, abonnement: 52.08 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 24.52 }
+})),
         hc: [{
             start: {hour:0, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/ekwateur/ElectriciteVerteFixeHPHC.js
+++ b/scripts/tarifs/ekwateur/ElectriciteVerteFixeHPHC.js
@@ -2,78 +2,19 @@ abonnements.push({
     name: "Ekwateur - Electricité verte fixe HP HC",
     lastUpdate: "2024-01-30",
     prices: [
-		{
-            puissance: 3,
-            abonnement: 13.29,
-            bleu: {
-                prixKwhHP: 27.14,
-                prixKwhHC: 19.22
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 16.54,
-            bleu: {
-                prixKwhHP: 27.14,
-                prixKwhHC: 19.22
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 19.95,
-            bleu: {
-                prixKwhHP: 27.14,
-                prixKwhHC: 19.22
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 23.29,
-            bleu: {
-                prixKwhHP: 27.14,
-                prixKwhHC: 19.22
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 26.43,
-            bleu: {
-                prixKwhHP: 27.14,
-                prixKwhHC: 19.22
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 29.69,
-            bleu: {
-                prixKwhHP: 27.14,
-                prixKwhHC: 19.22
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 36.31,
-            bleu: {
-                prixKwhHP: 27.14,
-                prixKwhHC: 19.22
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 45.04,
-            bleu: {
-                prixKwhHP: 27.14,
-                prixKwhHC: 19.22
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 52.8,
-            bleu: {
-                prixKwhHP: 27.14,
-                prixKwhHC: 19.22
-            }
-        }],
+    { puissance: 3, abonnement: 13.29 },
+    { puissance: 6, abonnement: 16.54 },
+    { puissance: 9, abonnement: 19.95 },
+    { puissance: 12, abonnement: 23.29 },
+    { puissance: 15, abonnement: 26.43 },
+    { puissance: 18, abonnement: 29.69 },
+    { puissance: 24, abonnement: 36.31 },
+    { puissance: 30, abonnement: 45.04 },
+    { puissance: 36, abonnement: 52.8 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 27.14, prixKwhHC: 19.22 }
+})),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,

--- a/scripts/tarifs/ekwateur/ElectriciteVerteVariable.js
+++ b/scripts/tarifs/ekwateur/ElectriciteVerteVariable.js
@@ -2,69 +2,20 @@ abonnements.push(
     {
         name: "Ekwateur - Electricité verte variable",
         lastUpdate: "2024-01-30",
-        prices: [{
-            puissance: 3,
-            abonnement: 13.29,
-            bleu: {
-                prixKwhHC: 19.4
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 16.54,
-            bleu: {
-                prixKwhHC: 20.96
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 19.95,
-            bleu: {
-                prixKwhHC: 21.2
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 23.29,
-            bleu: {
-                prixKwhHC: 21.8
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 26.43,
-            bleu: {
-                prixKwhHC: 21.8
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 29.69,
-            bleu: {
-                prixKwhHC: 21.8
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 36.31,
-            bleu: {
-                prixKwhHC: 21.876
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 45.04,
-            bleu: {
-                prixKwhHC: 21.8
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 52.8,
-            bleu: {
-                prixKwhHC: 21.8
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 13.29 },
+    { puissance: 6, abonnement: 16.54 },
+    { puissance: 9, abonnement: 19.95 },
+    { puissance: 12, abonnement: 23.29 },
+    { puissance: 15, abonnement: 26.43 },
+    { puissance: 18, abonnement: 29.69 },
+    { puissance: 24, abonnement: 36.31 },
+    { puissance: 30, abonnement: 45.04 },
+    { puissance: 36, abonnement: 52.8 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 19.4 }
+})),
         hc: [{
             start: {hour:0, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/ekwateur/ElectriciteVerteVariableHPHC.js
+++ b/scripts/tarifs/ekwateur/ElectriciteVerteVariableHPHC.js
@@ -2,78 +2,19 @@ abonnements.push({
     name: "Ekwateur - Electricité verte variable HP HC",
     lastUpdate: "2023-01-30",
     prices: [
-        {
-            puissance: 3,
-            abonnement: 13.29,
-            bleu: {
-                prixKwhHP: 24.00,
-                prixKwhHC: 17.07
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 16.54,
-            bleu: {
-                prixKwhHP: 24.00,
-                prixKwhHC: 17.07
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 19.95,
-            bleu: {
-                prixKwhHP: 24.00,
-                prixKwhHC: 17.07
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 23.29,
-            bleu: {
-                prixKwhHP: 24.00,
-                prixKwhHC: 17.07
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 26.43,
-            bleu: {
-                prixKwhHP: 24.00,
-                prixKwhHC: 17.07
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 29.69,
-            bleu: {
-                prixKwhHP: 24.00,
-                prixKwhHC: 17.07
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 36.31,
-            bleu: {
-                prixKwhHP: 24.00,
-                prixKwhHC: 17.07
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 45.04,
-            bleu: {
-                prixKwhHP: 24.00,
-                prixKwhHC: 17.07
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 52.8,
-            bleu: {
-                prixKwhHP: 24.00,
-                prixKwhHC: 17.07
-            }
-        }],
+    { puissance: 3, abonnement: 13.29 },
+    { puissance: 6, abonnement: 16.54 },
+    { puissance: 9, abonnement: 19.95 },
+    { puissance: 12, abonnement: 23.29 },
+    { puissance: 15, abonnement: 26.43 },
+    { puissance: 18, abonnement: 29.69 },
+    { puissance: 24, abonnement: 36.31 },
+    { puissance: 30, abonnement: 45.04 },
+    { puissance: 36, abonnement: 52.8 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 24.00, prixKwhHC: 17.07 }
+})),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,

--- a/scripts/tarifs/enercoop/base.js
+++ b/scripts/tarifs/enercoop/base.js
@@ -1,83 +1,31 @@
-abonnements.push(
-    {
-        name: "Enercoop - Base",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://souscription.enercoop.fr",
-        price_url: "https://www.faq.enercoop.fr/hc/fr/articles/360024967152-Annexes-tarifaires",
-        prices: [{
-            puissance: 3,
-            abonnement: 10.10,
-            bleu: {
-                prixKwhHC: 22.234
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 16.02,
-            bleu: {
-                prixKwhHC: 22.234
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 22.28,
-            bleu: {
-                prixKwhHC: 22.602
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 27.68,
-            bleu: {
-                prixKwhHC: 22.602
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 33.65,
-            bleu: {
-                prixKwhHC: 22.602
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 39.62,
-            bleu: {
-                prixKwhHC: 22.602
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 51.57,
-            bleu: {
-                prixKwhHC: 22.602
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 63.51,
-            bleu: {
-                prixKwhHC: 22.602
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 75.46,
-            bleu: {
-                prixKwhHC: 22.602
-            }
-        }],
-        hc: [{
-            start: { hour: 0, minute: 0 },
-            end: { hour: 24, minute: 0 }
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "Enercoop - Base",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://souscription.enercoop.fr",
+    price_url: "https://www.faq.enercoop.fr/hc/fr/articles/360024967152-Annexes-tarifaires",
+    prices: [
+        { puissance: 3, abonnement: 10.10, prixKwhHC: 22.234 },
+        { puissance: 6, abonnement: 16.02, prixKwhHC: 22.234 },
+        { puissance: 9, abonnement: 22.28, prixKwhHC: 22.602 },
+        { puissance: 12, abonnement: 27.68, prixKwhHC: 22.602 },
+        { puissance: 15, abonnement: 33.65, prixKwhHC: 22.602 },
+        { puissance: 18, abonnement: 39.62, prixKwhHC: 22.602 },
+        { puissance: 24, abonnement: 51.57, prixKwhHC: 22.602 },
+        { puissance: 30, abonnement: 63.51, prixKwhHC: 22.602 },
+        { puissance: 36, abonnement: 75.46, prixKwhHC: 22.602 }
+    ].map(item => ({
+        puissance: item.puissance,
+        abonnement: item.abonnement,
+        bleu: { prixKwhHC: item.prixKwhHC }
+    })),
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/enercoop/baseHC.js
+++ b/scripts/tarifs/enercoop/baseHC.js
@@ -1,87 +1,30 @@
-abonnements.push(
-    {
-        name: "Enercoop - Heures Creuses",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://souscription.enercoop.fr",
-        price_url: "https://www.faq.enercoop.fr/hc/fr/articles/360024967152-Annexes-tarifaires",
-        prices: [
-            {
-                puissance: 3,
-                abonnement: 11.49,
-                bleu: {
-                    prixKwhHC: 22.234
-                }
-            },
-            {
-                puissance: 6,
-                abonnement: 19.19,
-                bleu: {
-                    prixKwhHP: 24.758,
-                    prixKwhHC: 16.780
-                }
-            },
-            {
-                puissance: 9,
-                abonnement: 25.82,
-                bleu: {
-                    prixKwhHP: 24.758,
-                    prixKwhHC: 16.780
-                }
-            },
-            {
-                puissance: 12,
-                abonnement: 31.74,
-                bleu: {
-                    prixKwhHP: 24.758,
-                    prixKwhHC: 16.780
-                }
-            },
-            {
-                puissance: 15,
-                abonnement: 37.67,
-                bleu: {
-                    prixKwhHP: 24.758,
-                    prixKwhHC: 16.780
-                }
-            },
-            {
-                puissance: 18,
-                abonnement: 43.59,
-                bleu: {
-                    prixKwhHP: 24.758,
-                    prixKwhHC: 16.780
-                }
-            },
-            {
-                puissance: 24,
-                abonnement: 55.44,
-                bleu: {
-                    prixKwhHP: 24.758,
-                    prixKwhHC: 16.780
-                }
-            },
-            {
-                puissance: 30,
-                abonnement: 67.29,
-                bleu: {
-                    prixKwhHP: 24.758,
-                    prixKwhHC: 16.780
-                }
-            },
-            {
-                puissance: 36,
-                abonnement: 79.14,
-                bleu: {
-                    prixKwhHP: 24.758,
-                    prixKwhHC: 16.780
-                }
-            }],
-        hc: [],
-        hasHCCustom: true,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
-    });
+abonnements.push({
+    name: "Enercoop - Heures Creuses",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://souscription.enercoop.fr",
+    price_url: "https://www.faq.enercoop.fr/hc/fr/articles/360024967152-Annexes-tarifaires",
+    prices: [
+        { puissance: 3, abonnement: 11.49, prixKwhHC: 22.234 },
+        { puissance: 6, abonnement: 19.19, prixKwhHP: 24.758, prixKwhHC: 16.780 },
+        { puissance: 9, abonnement: 25.82, prixKwhHP: 24.758, prixKwhHC: 16.780 },
+        { puissance: 12, abonnement: 31.74, prixKwhHP: 24.758, prixKwhHC: 16.780 },
+        { puissance: 15, abonnement: 37.67, prixKwhHP: 24.758, prixKwhHC: 16.780 },
+        { puissance: 18, abonnement: 43.59, prixKwhHP: 24.758, prixKwhHC: 16.780 },
+        { puissance: 24, abonnement: 55.44, prixKwhHP: 24.758, prixKwhHC: 16.780 },
+        { puissance: 30, abonnement: 67.29, prixKwhHP: 24.758, prixKwhHC: 16.780 },
+        { puissance: 36, abonnement: 79.14, prixKwhHP: 24.758, prixKwhHC: 16.780 }
+    ].map(item => ({
+        puissance: item.puissance,
+        abonnement: item.abonnement,
+        bleu: item.prixKwhHP
+            ? { prixKwhHP: item.prixKwhHP, prixKwhHC: item.prixKwhHC }
+            : { prixKwhHC: item.prixKwhHC }
+    })),
+    hc: [],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
+    }
+});

--- a/scripts/tarifs/enercoop/saisons.js
+++ b/scripts/tarifs/enercoop/saisons.js
@@ -4,120 +4,26 @@ abonnements.push({
     subscription_url: "https://souscription.enercoop.fr",
     price_url: "https://www.faq.enercoop.fr/hc/fr/articles/360024967152-Annexes-tarifaires",
     prices: [
-        {
-            puissance: 3,
-            abonnement: 10.18,
-            basseSaison: {
-                prixKwhHP: 18.916,
-                prixKwhHC: 13.946
-            },
-            hauteSaison: {
-                prixKwhHP: 27.058,
-                prixKwhHC: 16.044
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 16.19,
-            basseSaison: {
-                prixKwhHP: 18.916,
-                prixKwhHC: 13.946
-            },
-            hauteSaison: {
-                prixKwhHP: 27.058,
-                prixKwhHC: 16.044
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 21.55,
-            basseSaison: {
-                prixKwhHP: 18.916,
-                prixKwhHC: 13.946
-            },
-            hauteSaison: {
-                prixKwhHP: 27.058,
-                prixKwhHC: 16.044
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 26.79,
-            basseSaison: {
-                prixKwhHP: 18.916,
-                prixKwhHC: 13.946
-            },
-            hauteSaison: {
-                prixKwhHP: 27.058,
-                prixKwhHC: 16.044
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 32.58,
-            basseSaison: {
-                prixKwhHP: 18.916,
-                prixKwhHC: 13.946
-            },
-            hauteSaison: {
-                prixKwhHP: 27.058,
-                prixKwhHC: 16.044
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 38.36,
-            basseSaison: {
-                prixKwhHP: 18.916,
-                prixKwhHC: 13.946
-            },
-            hauteSaison: {
-                prixKwhHP: 27.058,
-                prixKwhHC: 16.044
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 49.94,
-            basseSaison: {
-                prixKwhHP: 18.916,
-                prixKwhHC: 13.946
-            },
-            hauteSaison: {
-                prixKwhHP: 27.058,
-                prixKwhHC: 16.044
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 61.52,
-            basseSaison: {
-                prixKwhHP: 18.916,
-                prixKwhHC: 13.946
-            },
-            hauteSaison: {
-                prixKwhHP: 27.058,
-                prixKwhHC: 16.044
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 73.09,
-            basseSaison: {
-                prixKwhHP: 18.916,
-                prixKwhHC: 13.946
-            },
-            hauteSaison: {
-                prixKwhHP: 27.058,
-                prixKwhHC: 16.044
-            }
-        }],
+        { puissance: 3, abonnement: 10.18 },
+        { puissance: 6, abonnement: 16.19 },
+        { puissance: 9, abonnement: 21.55 },
+        { puissance: 12, abonnement: 26.79 },
+        { puissance: 15, abonnement: 32.58 },
+        { puissance: 18, abonnement: 38.36 },
+        { puissance: 24, abonnement: 49.94 },
+        { puissance: 30, abonnement: 61.52 },
+        { puissance: 36, abonnement: 73.09 }
+    ].map(item => ({
+        ...item,
+        basseSaison: { prixKwhHP: 18.916, prixKwhHC: 13.946 },
+        hauteSaison: { prixKwhHP: 27.058, prixKwhHC: 16.044 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     getDayType: function (day) {
         let dayType = "basseSaison";
-        const [currentyear, currentMonth, currentDay] = (day.date.split("/")).map(Number);
+        const [currentYear, currentMonth, currentDay] = day.date.split("/").map(Number);
 
         if ((currentMonth >= 11 && currentDay >= 1) || (currentMonth <= 3 && currentDay <= 31)) {
             dayType = "hauteSaison";

--- a/scripts/tarifs/engie/electTranquilite1an.js
+++ b/scripts/tarifs/engie/electTranquilite1an.js
@@ -1,82 +1,29 @@
-abonnements.push(
-    {
-        name: "Engie - Elec Tranquillité 1 an",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://particuliers.engie.fr/electricite.html",
-        price_url: "https://particuliers.engie.fr/content/dam/pdf/fiches-descriptives/fiche-descriptive-elec-tranquillite.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.71,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.95,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.26,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.35,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.41,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.20,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.00,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.82,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        }],
-        hc: [{
-            start: {hour:0, minute:0},
-            end: {hour:24, minute:0}
-        }],
-        hasHCCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "Engie - Elec Tranquillité 1 an",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://particuliers.engie.fr/electricite.html",
+    price_url: "https://particuliers.engie.fr/content/dam/pdf/fiches-descriptives/fiche-descriptive-elec-tranquillite.pdf",
+    prices: [
+        { puissance: 3, abonnement: 9.69 },
+        { puissance: 6, abonnement: 12.71 },
+        { puissance: 9, abonnement: 15.95 },
+        { puissance: 12, abonnement: 19.26 },
+        { puissance: 15, abonnement: 22.35 },
+        { puissance: 18, abonnement: 25.41 },
+        { puissance: 24, abonnement: 32.20 },
+        { puissance: 30, abonnement: 38.00 },
+        { puissance: 36, abonnement: 44.82 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 25.164 }
+    })),
+    hc: [{
+        start: { hour: 0, minute: 0 },
+        end: { hour: 24, minute: 0 }
+    }],
+    hasHCCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/engie/electTranquilite1anHC.js
+++ b/scripts/tarifs/engie/electTranquilite1anHC.js
@@ -1,89 +1,29 @@
-abonnements.push(
-    {
-        name: "Engie - Elec Tranquillité 1 an HC",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://particuliers.engie.fr/electricite.html",
-        price_url: "https://particuliers.engie.fr/content/dam/pdf/fiches-descriptives/fiche-descriptive-elec-tranquillite.pdf",
-        prices: [
-        {
-            puissance: 6,
-            abonnement: 13.39,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.676
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 17.00,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.676
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.52,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.676
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.89,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.676
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 27.22,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.676
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 34.22,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.676
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 40.60,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.676
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 47.04,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.676
-            }
-        }],
-        hc: [{
-            start: {hour:22, minute:0},
-            end: {hour:24, minute:0}
-        },
-        {
-            start: {hour:0, minute:0},
-            end: {hour:6, minute:0}
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "Engie - Elec Tranquillité 1 an HC",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://particuliers.engie.fr/electricite.html",
+    price_url: "https://particuliers.engie.fr/content/dam/pdf/fiches-descriptives/fiche-descriptive-elec-tranquillite.pdf",
+    prices: [
+        { puissance: 6, abonnement: 13.39 },
+        { puissance: 9, abonnement: 17.00 },
+        { puissance: 12, abonnement: 20.52 },
+        { puissance: 15, abonnement: 23.89 },
+        { puissance: 18, abonnement: 27.22 },
+        { puissance: 24, abonnement: 34.22 },
+        { puissance: 30, abonnement: 40.60 },
+        { puissance: 36, abonnement: 47.04 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 27.00, prixKwhHC: 20.676 }
+    })),
+    hc: [
+        { start: { hour: 22, minute: 0 }, end: { hour: 24, minute: 0 } },
+        { start: { hour: 0, minute: 0 }, end: { hour: 6, minute: 0 } }
+    ],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/es/bleu.js
+++ b/scripts/tarifs/es/bleu.js
@@ -1,56 +1,24 @@
-abonnements.push(
-    {
-        name: "ES - Bleu",
-        offer_type: "TRV",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://particuliers.es.fr/Offres-energies-services/Electricite-Gaz/Les-offres-electricite-d-ES/Tarif-Reglemente-electricite",
-        price_url: "https://particuliers.es.fr/Media/Files/Part/Documentation-electricite/Tarif-reglemente-Fiche-descriptive-de-l-offre",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.71,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.96,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.27,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.35,
-            bleu: {
-                prixKwhHC: 25.164
-            }
-        }],
-        hc: [{
-            start: {hour:0, minute:0},
-            end: {hour:24, minute:0}
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "ES - Bleu",
+    offer_type: "TRV",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://particuliers.es.fr/Offres-energies-services/Electricite-Gaz/Les-offres-electricite-d-ES/Tarif-Reglemente-electricite",
+    price_url: "https://particuliers.es.fr/Media/Files/Part/Documentation-electricite/Tarif-reglemente-Fiche-descriptive-de-l-offre",
+    prices: [
+        { puissance: 3, abonnement: 9.69 },
+        { puissance: 6, abonnement: 12.71 },
+        { puissance: 9, abonnement: 15.96 },
+        { puissance: 12, abonnement: 19.27 },
+        { puissance: 15, abonnement: 22.35 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 25.164 }
+    })),
+    hc: [{ start: { hour: 0, minute: 0 }, end: { hour: 24, minute: 0 } }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/es/bleuHC.js
+++ b/scripts/tarifs/es/bleuHC.js
@@ -1,84 +1,27 @@
-abonnements.push(
-    {
-        name: "ES - Bleu Heures Creuses",
-        offer_type: "TRV",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://particuliers.es.fr/Offres-energies-services/Electricite-Gaz/Les-offres-electricite-d-ES/Tarif-Reglemente-electricite",
-        price_url: "https://particuliers.es.fr/Media/Files/Part/Documentation-electricite/Tarif-reglemente-Fiche-descriptive-de-l-offre",
-        prices: [
-            {
-                puissance: 6,
-                abonnement: 13.39,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.676
-                }
-            },
-            {
-                puissance: 9,
-                abonnement: 17.00,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.676
-                }
-            },
-            {
-                puissance: 12,
-                abonnement: 20.52,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.676
-                }
-            },
-            {
-                puissance: 15,
-                abonnement: 23.89,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.676
-                }
-            },
-            {
-                puissance: 18,
-                abonnement: 27.22,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.676
-                }
-            },
-            {
-                puissance: 24,
-                abonnement: 34.22,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.676
-                }
-            },
-            {
-                puissance: 30,
-                abonnement: 40.60,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.676
-                }
-            },
-            {
-                puissance: 36,
-                abonnement: 47.04,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.676
-                }
-            }],
-        hc: [{
-            start: {hour:23, minute:0},
-            end: {hour:7, minute:0}
-        }],
-        hasHCCustom: true,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
-    });
+abonnements.push({
+    name: "ES - Bleu Heures Creuses",
+    offer_type: "TRV",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://particuliers.es.fr/Offres-energies-services/Electricite-Gaz/Les-offres-electricite-d-ES/Tarif-Reglemente-electricite",
+    price_url: "https://particuliers.es.fr/Media/Files/Part/Documentation-electricite/Tarif-reglemente-Fiche-descriptive-de-l-offre",
+    prices: [
+        { puissance: 6, abonnement: 13.39 },
+        { puissance: 9, abonnement: 17.00 },
+        { puissance: 12, abonnement: 20.52 },
+        { puissance: 15, abonnement: 23.89 },
+        { puissance: 18, abonnement: 27.22 },
+        { puissance: 24, abonnement: 34.22 },
+        { puissance: 30, abonnement: 40.60 },
+        { puissance: 36, abonnement: 47.04 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 27.00, prixKwhHC: 20.676 }
+    })),
+    hc: [{ start: { hour: 23, minute: 0 }, end: { hour: 7, minute: 0 } }],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
+    }
+});

--- a/scripts/tarifs/es/tempo.js
+++ b/scripts/tarifs/es/tempo.js
@@ -3,120 +3,21 @@ abonnements.push({
     offer_type: "TRV",
     lastUpdate: "2024-02-01",
     subscription_url: "https://particuliers.es.fr/Offres-energies-services/Electricite-Gaz/Les-offres-electricite-d-ES/Tarif-Reglemente-electricite",
-        price_url: "https://particuliers.es.fr/Media/Files/Part/Documentation-electricite/Tarif-reglemente-Fiche-descriptive-de-l-offre",
-        prices: [
-        {
-            puissance: 6,
-            abonnement: 13.33,
-            bleu: {
-                prixKwhHP: 16.092,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.936,
-                prixKwhHC: 14.856
-            },
-            rouge: {
-                prixKwhHP: 75.624,
-                prixKwhHC: 15.684
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.72,
-            bleu: {
-                prixKwhHP: 16.092,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.936,
-                prixKwhHC: 14.856
-            },
-            rouge: {
-                prixKwhHP: 75.624,
-                prixKwhHC: 15.684
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.19,
-            bleu: {
-                prixKwhHP: 16.092,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.936,
-                prixKwhHC: 14.856
-            },
-            rouge: {
-                prixKwhHP: 75.624,
-                prixKwhHC: 15.684
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.39,
-            bleu: {
-                prixKwhHP: 16.092,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.936,
-                prixKwhHC: 14.856
-            },
-            rouge: {
-                prixKwhHP: 75.624,
-                prixKwhHC: 15.684
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.57,
-            bleu: {
-                prixKwhHP: 16.092,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.936,
-                prixKwhHC: 14.856
-            },
-            rouge: {
-                prixKwhHP: 75.624,
-                prixKwhHC: 15.684
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 40.16,
-            bleu: {
-                prixKwhHP: 16.092,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.936,
-                prixKwhHC: 14.856
-            },
-            rouge: {
-                prixKwhHP: 75.624,
-                prixKwhHC: 15.684
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 46.67,
-            bleu: {
-                prixKwhHP: 16.092,
-                prixKwhHC: 12.96
-            },
-            blanc: {
-                prixKwhHP: 18.936,
-                prixKwhHC: 14.856
-            },
-            rouge: {
-                prixKwhHP: 75.624,
-                prixKwhHC: 15.684
-            }
-        }],
+    price_url: "https://particuliers.es.fr/Media/Files/Part/Documentation-electricite/Tarif-reglemente-Fiche-descriptive-de-l-offre",
+    prices: [
+        { puissance: 6, abonnement: 13.33 },
+        { puissance: 9, abonnement: 16.72 },
+        { puissance: 12, abonnement: 20.19 },
+        { puissance: 15, abonnement: 23.39 },
+        { puissance: 18, abonnement: 26.57 },
+        { puissance: 30, abonnement: 40.16 },
+        { puissance: 36, abonnement: 46.67 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 16.092, prixKwhHC: 12.96 },
+        blanc: { prixKwhHP: 18.936, prixKwhHC: 14.856 },
+        rouge: { prixKwhHP: 75.624, prixKwhHC: 15.684 }
+    })),
     hc: [{
         start: {hour:22, minute:0},
         end: {hour:24, minute:0}

--- a/scripts/tarifs/ilek/base.js
+++ b/scripts/tarifs/ilek/base.js
@@ -1,83 +1,27 @@
-abonnements.push(
-    {
-        name: "Ilek - Base",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://www.ilek.fr/grilles-tarifaires",
-        price_url: "https://ilek.s3.amazonaws.com/uploads/producer/price_list_file/229/grille_electricite.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 14.85,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 20.53,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 28.01,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 35.85,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 41.24,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 45.28,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 54.29,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 64.70,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 74.03,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        }],
-        hc: [{
-            start: {hour:0, minute:0},
-            end: {hour:24, minute:0}
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "Ilek - Base",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://www.ilek.fr/grilles-tarifaires",
+    price_url: "https://ilek.s3.amazonaws.com/uploads/producer/price_list_file/229/grille_electricite.pdf",
+    prices: [
+        { puissance: 3, abonnement: 14.85 },
+        { puissance: 6, abonnement: 20.53 },
+        { puissance: 9, abonnement: 28.01 },
+        { puissance: 12, abonnement: 35.85 },
+        { puissance: 15, abonnement: 41.24 },
+        { puissance: 18, abonnement: 45.28 },
+        { puissance: 24, abonnement: 54.29 },
+        { puissance: 30, abonnement: 64.70 },
+        { puissance: 36, abonnement: 74.03 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 25.16 }
+    })),
+    hc: [{ start: { hour: 0, minute: 0 }, end: { hour: 24, minute: 0 } }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/ilek/hc.js
+++ b/scripts/tarifs/ilek/hc.js
@@ -1,80 +1,26 @@
-abonnements.push(
-    {
-        name: "Ilek - Heures Creuses",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://www.ilek.fr/grilles-tarifaires",
-        price_url: "https://ilek.s3.amazonaws.com/uploads/producer/price_list_file/229/grille_electricite.pdf",
-        prices: [
-            {
-                puissance: 6,
-                abonnement: 23.70,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 9,
-                abonnement: 32.93,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 12,
-                abonnement: 38.47,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 15,
-                abonnement: 43.97,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 18,
-                abonnement: 48.62,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 24,
-                abonnement: 58.45,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 30,
-                abonnement: 62.28,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            },
-            {
-                puissance: 36,
-                abonnement: 74.14,
-                bleu: {
-                    prixKwhHP: 27.00,
-                    prixKwhHC: 20.68
-                }
-            }],
-        hc: [],
-        hasHCCustom: true,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
-    });
+abonnements.push({
+    name: "Ilek - Heures Creuses",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://www.ilek.fr/grilles-tarifaires",
+    price_url: "https://ilek.s3.amazonaws.com/uploads/producer/price_list_file/229/grille_electricite.pdf",
+    prices: [
+        { puissance: 6, abonnement: 23.70 },
+        { puissance: 9, abonnement: 32.93 },
+        { puissance: 12, abonnement: 38.47 },
+        { puissance: 15, abonnement: 43.97 },
+        { puissance: 18, abonnement: 48.62 },
+        { puissance: 24, abonnement: 58.45 },
+        { puissance: 30, abonnement: 62.28 },
+        { puissance: 36, abonnement: 74.14 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 27.00, prixKwhHC: 20.68 }
+    })),
+    hc: [],
+    hasHCCustom: true,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
+    }
+});

--- a/scripts/tarifs/labelleenergie/constance.js
+++ b/scripts/tarifs/labelleenergie/constance.js
@@ -4,69 +4,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://labellenergie.fr/offre-electricite-verte/",
         price_url: "https://labellenergie.fr/pdf/grille-tarifaire-la-bellenergie-particuliers.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 11.68,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 14.71,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 17.95,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 21.26,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 24.35,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 27.41,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 34.20,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.99,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 46.81,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 11.68 },
+    { puissance: 6, abonnement: 14.71 },
+    { puissance: 9, abonnement: 17.95 },
+    { puissance: 12, abonnement: 21.26 },
+    { puissance: 15, abonnement: 24.35 },
+    { puissance: 18, abonnement: 27.41 },
+    { puissance: 24, abonnement: 34.20 },
+    { puissance: 30, abonnement: 39.99 },
+    { puissance: 36, abonnement: 46.81 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 20.64 }
+})),
+
         hc: [{
             start: {hour:0, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/labelleenergie/constanceHC.js
+++ b/scripts/tarifs/labelleenergie/constanceHC.js
@@ -5,70 +5,19 @@ abonnements.push(
         subscription_url: "https://labellenergie.fr/offre-electricite-verte/",
         price_url: "https://labellenergie.fr/pdf/grille-tarifaire-la-bellenergie-particuliers.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 15.38,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 18.99,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 22.52,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 25.88,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 29.22,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 36.22,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 42.60,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 49.04,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        }],
+    { puissance: 6, abonnement: 15.38 },
+    { puissance: 9, abonnement: 18.99 },
+    { puissance: 12, abonnement: 22.52 },
+    { puissance: 15, abonnement: 25.88 },
+    { puissance: 18, abonnement: 29.22 },
+    { puissance: 24, abonnement: 36.22 },
+    { puissance: 30, abonnement: 42.60 },
+    { puissance: 36, abonnement: 49.04 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 22.10, prixKwhHC: 17.04 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/labelleenergie/garance.js
+++ b/scripts/tarifs/labelleenergie/garance.js
@@ -4,69 +4,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://labellenergie.fr/offre-electricite-verte/",
         price_url: "https://labellenergie.fr/pdf/grille-tarifaire-la-bellenergie-particuliers.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 14.68,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 17.70,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 20.95,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 24.26,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 27.34,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 30.41,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 37.20,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 42.99,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 49.81,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 14.68 },
+    { puissance: 6, abonnement: 17.70 },
+    { puissance: 9, abonnement: 20.95 },
+    { puissance: 12, abonnement: 24.26 },
+    { puissance: 15, abonnement: 27.34 },
+    { puissance: 18, abonnement: 30.41 },
+    { puissance: 24, abonnement: 37.20 },
+    { puissance: 30, abonnement: 42.99 },
+    { puissance: 36, abonnement: 49.81 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 20.64 }
+})),
+
         hc: [{
             start: {hour:0, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/labelleenergie/garanceHC.js
+++ b/scripts/tarifs/labelleenergie/garanceHC.js
@@ -5,70 +5,19 @@ abonnements.push(
         subscription_url: "https://labellenergie.fr/offre-electricite-verte/",
         price_url: "https://labellenergie.fr/pdf/grille-tarifaire-la-bellenergie-particuliers.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 18.38,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 21.99,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 25.51,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 28.88,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 32.21,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 39.21,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 45.60,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 52.03,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        }],
+    { puissance: 6, abonnement: 18.38 },
+    { puissance: 9, abonnement: 21.99 },
+    { puissance: 12, abonnement: 25.51 },
+    { puissance: 15, abonnement: 28.88 },
+    { puissance: 18, abonnement: 32.21 },
+    { puissance: 24, abonnement: 39.21 },
+    { puissance: 30, abonnement: 45.60 },
+    { puissance: 36, abonnement: 52.03 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 22.10, prixKwhHC: 17.04 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/labelleenergie/prudence.js
+++ b/scripts/tarifs/labelleenergie/prudence.js
@@ -4,69 +4,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://labellenergie.fr/offre-electricite-verte/",
         price_url: "https://labellenergie.fr/pdf/grille-tarifaire-la-bellenergie-particuliers.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.45,
-            bleu: {
-                prixKwhHC: 18.78
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.42,
-            bleu: {
-                prixKwhHC: 18.78
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.61,
-            bleu: {
-                prixKwhHC: 18.78
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 18.86,
-            bleu: {
-                prixKwhHC: 18.78
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 21.90,
-            bleu: {
-                prixKwhHC: 18.78
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 24.91,
-            bleu: {
-                prixKwhHC: 18.78
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.58,
-            bleu: {
-                prixKwhHC: 18.78
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.26,
-            bleu: {
-                prixKwhHC: 18.78
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 43.97,
-            bleu: {
-                prixKwhHC: 18.78
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 9.45 },
+    { puissance: 6, abonnement: 12.42 },
+    { puissance: 9, abonnement: 15.61 },
+    { puissance: 12, abonnement: 18.86 },
+    { puissance: 15, abonnement: 21.90 },
+    { puissance: 18, abonnement: 24.91 },
+    { puissance: 24, abonnement: 31.58 },
+    { puissance: 30, abonnement: 37.26 },
+    { puissance: 36, abonnement: 43.97 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 18.78 }
+})),
+
         hc: [{
             start: {hour:0, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/labelleenergie/prudenceHC.js
+++ b/scripts/tarifs/labelleenergie/prudenceHC.js
@@ -5,70 +5,19 @@ abonnements.push(
         subscription_url: "https://labellenergie.fr/offre-electricite-verte/",
         price_url: "https://labellenergie.fr/pdf/grille-tarifaire-la-bellenergie-particuliers.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 12.83,
-            bleu: {
-                prixKwhHP: 20.10,
-                prixKwhHC: 15.55
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.53,
-            bleu: {
-                prixKwhHP: 20.10,
-                prixKwhHC: 15.55
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.95,
-            bleu: {
-                prixKwhHP: 20.10,
-                prixKwhHC: 15.55
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.22,
-            bleu: {
-                prixKwhHP: 20.10,
-                prixKwhHC: 15.55
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.46,
-            bleu: {
-                prixKwhHP: 20.10,
-                prixKwhHC: 15.55
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.26,
-            bleu: {
-                prixKwhHP: 20.10,
-                prixKwhHC: 15.55
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.45,
-            bleu: {
-                prixKwhHP: 20.10,
-                prixKwhHC: 15.55
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.70,
-            bleu: {
-                prixKwhHP: 20.10,
-                prixKwhHC: 15.55
-            }
-        }],
+    { puissance: 6, abonnement: 12.83 },
+    { puissance: 9, abonnement: 16.53 },
+    { puissance: 12, abonnement: 19.95 },
+    { puissance: 15, abonnement: 23.22 },
+    { puissance: 18, abonnement: 26.46 },
+    { puissance: 24, abonnement: 33.26 },
+    { puissance: 30, abonnement: 39.45 },
+    { puissance: 36, abonnement: 45.70 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 20.10, prixKwhHC: 15.55 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/mint/classicEtGreen.js
+++ b/scripts/tarifs/mint/classicEtGreen.js
@@ -4,69 +4,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://www.mint-energie.com/Pages/Informations/tarifs_elec.aspx",
         price_url: "https://doc.mint-energie.com/MintEnergie/MINT_ENERGIE_Fiche_Tarifs_14624_CLASSIC_GREEN.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 10.11,
-            bleu: {
-                prixKwhHC: 22.90
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 13.25,
-            bleu: {
-                prixKwhHC: 22.90
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.63,
-            bleu: {
-                prixKwhHC: 22.90
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.08,
-            bleu: {
-                prixKwhHC: 22.90
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.29,
-            bleu: {
-                prixKwhHC: 22.90
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.48,
-            bleu: {
-                prixKwhHC: 22.90
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.55,
-            bleu: {
-                prixKwhHC: 22.90
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.58,
-            bleu: {
-                prixKwhHC: 22.90
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 46.68,
-            bleu: {
-                prixKwhHC: 22.90
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 10.11 },
+    { puissance: 6, abonnement: 13.25 },
+    { puissance: 9, abonnement: 16.63 },
+    { puissance: 12, abonnement: 20.08 },
+    { puissance: 15, abonnement: 23.29 },
+    { puissance: 18, abonnement: 26.48 },
+    { puissance: 24, abonnement: 33.55 },
+    { puissance: 30, abonnement: 39.58 },
+    { puissance: 36, abonnement: 46.68 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 22.90 }
+})),
+
         hc: [{
             start: { hour: 0, minute: 0 },
             end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/mint/classicEtGreenHC.js
+++ b/scripts/tarifs/mint/classicEtGreenHC.js
@@ -5,70 +5,19 @@ abonnements.push(
         subscription_url: "https://www.mint-energie.com/Pages/Informations/tarifs_elec.aspx",
         price_url: "https://doc.mint-energie.com/MintEnergie/MINT_ENERGIE_Fiche_Tarifs_14624_CLASSIC_GREEN.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 13.95,
-            bleu: {
-                prixKwhHP: 24.55,
-                prixKwhHC: 18.86
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 17.70,
-            bleu: {
-                prixKwhHP: 24.55,
-                prixKwhHC: 18.86
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 21.37,
-            bleu: {
-                prixKwhHP: 24.55,
-                prixKwhHC: 18.86
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 24.87,
-            bleu: {
-                prixKwhHP: 24.55,
-                prixKwhHC: 18.86
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 28.34,
-            bleu: {
-                prixKwhHP: 24.55,
-                prixKwhHC: 18.86
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 35.61,
-            bleu: {
-                prixKwhHP: 24.55,
-                prixKwhHC: 18.86
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 42.25,
-            bleu: {
-                prixKwhHP: 24.55,
-                prixKwhHC: 18.86
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 48.93,
-            bleu: {
-                prixKwhHP: 24.55,
-                prixKwhHC: 18.86
-            }
-        }],
+    { puissance: 6, abonnement: 13.95 },
+    { puissance: 9, abonnement: 17.70 },
+    { puissance: 12, abonnement: 21.37 },
+    { puissance: 15, abonnement: 24.87 },
+    { puissance: 18, abonnement: 28.34 },
+    { puissance: 24, abonnement: 35.61 },
+    { puissance: 30, abonnement: 42.25 },
+    { puissance: 36, abonnement: 48.93 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 24.55, prixKwhHC: 18.86 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/mint/onlineEtGreen.js
+++ b/scripts/tarifs/mint/onlineEtGreen.js
@@ -4,69 +4,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://www.mint-energie.com/Pages/Informations/tarifs_elec.aspx",
         price_url: "https://doc.mint-energie.com/MintEnergie/MINT_ENERGIE_Fiche_Tarifs_14512_ONLINE_GREEN.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 10.64,
-            bleu: {
-                prixKwhHC: 18.82
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 13.91,
-            bleu: {
-                prixKwhHC: 18.82
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.47,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.86,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.01,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.15,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.10,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.02,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 46.68,
-            bleu: {
-                prixKwhHC: 19.06
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 10.64 },
+    { puissance: 6, abonnement: 13.91 },
+    { puissance: 9, abonnement: 16.47 },
+    { puissance: 12, abonnement: 19.86 },
+    { puissance: 15, abonnement: 23.01 },
+    { puissance: 18, abonnement: 26.15 },
+    { puissance: 24, abonnement: 33.10 },
+    { puissance: 30, abonnement: 39.02 },
+    { puissance: 36, abonnement: 46.68 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 18.82 }
+})),
+
         hc: [{
             start: { hour: 0, minute: 0 },
             end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/mint/onlineEtGreenHC.js
+++ b/scripts/tarifs/mint/onlineEtGreenHC.js
@@ -5,70 +5,19 @@ abonnements.push(
         subscription_url: "https://www.mint-energie.com/Pages/Informations/tarifs_elec.aspx",
         price_url: "https://doc.mint-energie.com/MintEnergie/MINT_ENERGIE_Fiche_Tarifs_14512_ONLINE_GREEN.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 14.93,
-            bleu: {
-                prixKwhHP: 20.39,
-                prixKwhHC: 15.77
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 17.70,
-            bleu: {
-                prixKwhHP: 20.39,
-                prixKwhHC: 15.77
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 21.32,
-            bleu: {
-                prixKwhHP: 20.39,
-                prixKwhHC: 15.77
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 24.78,
-            bleu: {
-                prixKwhHP: 20.39,
-                prixKwhHC: 15.77
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 28.20,
-            bleu: {
-                prixKwhHP: 20.39,
-                prixKwhHC: 15.77
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 35.39,
-            bleu: {
-                prixKwhHP: 20.39,
-                prixKwhHC: 15.77
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 41.93,
-            bleu: {
-                prixKwhHP: 20.39,
-                prixKwhHC: 15.77
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 47.44,
-            bleu: {
-                prixKwhHP: 20.39,
-                prixKwhHC: 15.77
-            }
-        }],
+    { puissance: 6, abonnement: 14.93 },
+    { puissance: 9, abonnement: 17.70 },
+    { puissance: 12, abonnement: 21.32 },
+    { puissance: 15, abonnement: 24.78 },
+    { puissance: 18, abonnement: 28.20 },
+    { puissance: 24, abonnement: 35.39 },
+    { puissance: 30, abonnement: 41.93 },
+    { puissance: 36, abonnement: 47.44 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 20.39, prixKwhHC: 15.77 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/mint/smartEtGreen.js
+++ b/scripts/tarifs/mint/smartEtGreen.js
@@ -4,69 +4,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://www.mint-energie.com/Pages/Informations/tarifs_elec.aspx",
         price_url: "https://doc.mint-energie.com/MintEnergie/MINT_ENERGIE_Fiche_Tarifs_14712_SMART_GREEN.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.71,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.96,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.26,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.35,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.42,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.20,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.00,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.81,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 9.69 },
+    { puissance: 6, abonnement: 12.71 },
+    { puissance: 9, abonnement: 15.96 },
+    { puissance: 12, abonnement: 19.26 },
+    { puissance: 15, abonnement: 22.35 },
+    { puissance: 18, abonnement: 25.42 },
+    { puissance: 24, abonnement: 32.20 },
+    { puissance: 30, abonnement: 38.00 },
+    { puissance: 36, abonnement: 44.81 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 25.16 }
+})),
+
         hc: [{
             start: { hour: 0, minute: 0 },
             end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/mint/smartEtGreenHC.js
+++ b/scripts/tarifs/mint/smartEtGreenHC.js
@@ -5,70 +5,19 @@ abonnements.push(
         subscription_url: "https://www.mint-energie.com/Pages/Informations/tarifs_elec.aspx",
         price_url: "https://doc.mint-energie.com/MintEnergie/MINT_ENERGIE_Fiche_Tarifs_14512_ONLINE_GREEN.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 13.39,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 17.00,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.52,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.89,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 27.22,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 34.22,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 40.60,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 47.04,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        }],
+    { puissance: 6, abonnement: 13.39 },
+    { puissance: 9, abonnement: 17.00 },
+    { puissance: 12, abonnement: 20.52 },
+    { puissance: 15, abonnement: 23.89 },
+    { puissance: 18, abonnement: 27.22 },
+    { puissance: 24, abonnement: 34.22 },
+    { puissance: 30, abonnement: 40.60 },
+    { puissance: 36, abonnement: 47.04 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 27.00, prixKwhHC: 20.68 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/octopus/base.js
+++ b/scripts/tarifs/octopus/base.js
@@ -1,84 +1,28 @@
-abonnements.push(
-    {
-        name: "Octopus - Base",
-        offer_type: "Marché",
-        lastUpdate: "2024-05-13",
-        subscription_url: "https://www.octopusenergy.fr/offre-electricite-tarifs",
-        price_url: "https://a.storyblok.com/f/151412/x/a47d7d5ed1/grille-tarifaire-eco-conso-fixe-202405.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.63,
-            bleu: {
-                prixKwhHC: 20.18
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.60,
-            bleu: {
-                prixKwhHC: 20.18
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.79,
-            bleu: {
-                prixKwhHC: 20.18
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.04,
-            bleu: {
-                prixKwhHC: 20.18
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.08,
-            bleu: {
-                prixKwhHC: 20.18
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.09,
-            bleu: {
-                prixKwhHC: 20.18
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.76,
-            bleu: {
-                prixKwhHC: 20.18
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.44,
-            bleu: {
-                prixKwhHC: 20.18
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.82,
-            bleu: {
-                prixKwhHC: 20.18
-            }
-        }],
-        hc: [{
-            start: { hour: 0, minute: 0 },
-            end: { hour: 24, minute: 0 }
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "Octopus - Base",
+    offer_type: "Marché",
+    lastUpdate: "2024-05-13",
+    subscription_url: "https://www.octopusenergy.fr/offre-electricite-tarifs",
+    price_url: "https://a.storyblok.com/f/151412/x/a47d7d5ed1/grille-tarifaire-eco-conso-fixe-202405.pdf",
+    prices: [
+        { puissance: 3, abonnement: 9.63 },
+        { puissance: 6, abonnement: 12.60 },
+        { puissance: 9, abonnement: 15.79 },
+        { puissance: 12, abonnement: 19.04 },
+        { puissance: 15, abonnement: 22.08 },
+        { puissance: 18, abonnement: 25.09 },
+        { puissance: 24, abonnement: 31.76 },
+        { puissance: 30, abonnement: 37.44 },
+        { puissance: 36, abonnement: 44.82 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 20.18 }
+    })),
+    hc: [{ start: { hour: 0, minute: 0 }, end: { hour: 24, minute: 0 } }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/octopus/baseHC.js
+++ b/scripts/tarifs/octopus/baseHC.js
@@ -5,76 +5,23 @@ abonnements.push({
     subscription_url: "https://www.octopusenergy.fr/offre-electricite-tarifs",
     price_url: "https://a.storyblok.com/f/151412/x/a47d7d5ed1/grille-tarifaire-eco-conso-fixe-202405.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.01,
-            bleu: {
-                prixKwhHP: 21.61,
-                prixKwhHC: 16.68
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.71,
-            bleu: {
-                prixKwhHP: 21.61,
-                prixKwhHC: 16.68
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.13,
-            bleu: {
-                prixKwhHP: 21.61,
-                prixKwhHC: 16.68
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.40,
-            bleu: {
-                prixKwhHP: 21.61,
-                prixKwhHC: 16.68
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.64,
-            bleu: {
-                prixKwhHP: 21.61,
-                prixKwhHC: 16.68
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.44,
-            bleu: {
-                prixKwhHP: 21.61,
-                prixKwhHC: 16.68
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.63,
-            bleu: {
-                prixKwhHP: 21.61,
-                prixKwhHC: 16.68
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.79,
-            bleu: {
-                prixKwhHP: 21.61,
-                prixKwhHC: 16.68
-            }
-        }],
+        { puissance: 6, abonnement: 13.01 },
+        { puissance: 9, abonnement: 16.71 },
+        { puissance: 12, abonnement: 20.13 },
+        { puissance: 15, abonnement: 23.40 },
+        { puissance: 18, abonnement: 26.64 },
+        { puissance: 24, abonnement: 33.44 },
+        { puissance: 30, abonnement: 39.63 },
+        { puissance: 36, abonnement: 44.79 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 21.61, prixKwhHC: 16.68 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/ohm/classique.js
+++ b/scripts/tarifs/ohm/classique.js
@@ -5,69 +5,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://ohm-energie.com/offre/electricite",
         price_url: "https://ohm-energie.com/grilles/elec/2023Octobre/ELEC-Classique_202310.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 8.84,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 11.62,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 14.60,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 17.64,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 20.47,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 23.29,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 29.51,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 34.84,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 41.09,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 8.84 },
+    { puissance: 6, abonnement: 11.62 },
+    { puissance: 9, abonnement: 14.60 },
+    { puissance: 12, abonnement: 17.64 },
+    { puissance: 15, abonnement: 20.47 },
+    { puissance: 18, abonnement: 23.29 },
+    { puissance: 24, abonnement: 29.51 },
+    { puissance: 30, abonnement: 34.84 },
+    { puissance: 36, abonnement: 41.09 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 25.16 }
+})),
+
         hc: [{
             start: {hour:0, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/ohm/classiqueHC.js
+++ b/scripts/tarifs/ohm/classiqueHC.js
@@ -6,70 +6,19 @@ abonnements.push(
         subscription_url: "https://ohm-energie.com/offre/electricite",
         price_url: "https://ohm-energie.com/grilles/elec/2023Octobre/ELEC-Classique_202310.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 12.26,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.58,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 18.82,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 21.92,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 24.99,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.43,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.32,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 41.67,
-            bleu: {
-                prixKwhHP: 27.00,
-                prixKwhHC: 20.68
-            }
-        }],
+    { puissance: 6, abonnement: 12.26 },
+    { puissance: 9, abonnement: 15.58 },
+    { puissance: 12, abonnement: 18.82 },
+    { puissance: 15, abonnement: 21.92 },
+    { puissance: 18, abonnement: 24.99 },
+    { puissance: 24, abonnement: 31.43 },
+    { puissance: 30, abonnement: 37.32 },
+    { puissance: 36, abonnement: 41.67 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 27.00, prixKwhHC: 20.68 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/ohm/hyperEco.js
+++ b/scripts/tarifs/ohm/hyperEco.js
@@ -5,69 +5,21 @@ abonnements.push(
         lastUpdate: "2024-07-01",
         subscription_url: "https://ohm-energie.com/offre/electricite",
         price_url: "https://ohm-energie.com/grilles/elec/2024/06/HYPER-ECO-FIXE.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.63,
-            bleu: {
-                prixKwhHC: 20.64
-            }
-            },
-            {
-                puissance: 6,
-                abonnement: 12.60,
-                bleu: {
-                    prixKwhHC: 20.64
-                }
-            },
-            {
-                puissance: 9,
-                abonnement: 15.79,
-                bleu: {
-                    prixKwhHC: 20.64
-                }
-            },
-            {
-                puissance: 12,
-                abonnement: 19.04,
-                bleu: {
-                    prixKwhHC: 20.64
-                }
-            },
-            {
-                puissance: 15,
-                abonnement: 22.07,
-                bleu: {
-                    prixKwhHC: 20.64
-                }
-            },
-            {
-                puissance: 18,
-                abonnement: 25.08,
-                bleu: {
-                    prixKwhHC: 20.64
-                }
-            },
-            {
-                puissance: 24,
-                abonnement: 31.76,
-                bleu: {
-                    prixKwhHC: 20.64
-                }
-            },
-            {
-                puissance: 30,
-                abonnement: 37.44,
-                bleu: {
-                    prixKwhHC: 20.64
-                }
-            },
-            {
-                puissance: 36,
-                abonnement: 44.15,
-                bleu: {
-                    prixKwhHC: 20.64
-                }
-            }],
+        prices: [
+    { puissance: 3, abonnement: 9.63 },
+    { puissance: 6, abonnement: 12.60 },
+    { puissance: 9, abonnement: 15.79 },
+    { puissance: 12, abonnement: 19.04 },
+    { puissance: 15, abonnement: 22.07 },
+    { puissance: 18, abonnement: 25.08 },
+    { puissance: 24, abonnement: 31.76 },
+    { puissance: 30, abonnement: 37.44 },
+    { puissance: 36, abonnement: 44.15 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 20.64 }
+})),
+
         hc: [{
             start: {hour: 0, minute: 0},
             end: {hour: 24, minute: 0}

--- a/scripts/tarifs/ohm/hyperEcoHC.js
+++ b/scripts/tarifs/ohm/hyperEcoHC.js
@@ -6,70 +6,19 @@ abonnements.push(
         subscription_url: "https://ohm-energie.com/offre/electricite",
         price_url: "https://ohm-energie.com/grilles/elec/2024/06/HYPER-ECO-FIXE.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 13.19,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.70,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.13,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.40,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.64,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.44,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.63,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.87,
-            bleu: {
-                prixKwhHP: 22.10,
-                prixKwhHC: 17.04
-            }
-        }],
+    { puissance: 6, abonnement: 13.19 },
+    { puissance: 9, abonnement: 16.70 },
+    { puissance: 12, abonnement: 20.13 },
+    { puissance: 15, abonnement: 23.40 },
+    { puissance: 18, abonnement: 26.64 },
+    { puissance: 24, abonnement: 33.44 },
+    { puissance: 30, abonnement: 39.63 },
+    { puissance: 36, abonnement: 45.87 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 22.10, prixKwhHC: 17.04 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/ohm/soirWeekEndHC.js
+++ b/scripts/tarifs/ohm/soirWeekEndHC.js
@@ -6,114 +6,20 @@ abonnements.push(
         subscription_url: "https://ohm-energie.com/offre/electricite",
         price_url: "https://ohm-energie.com/grilles/elec/2024/02/ELEC_S%26WE.pdf",
         prices: [
-        {
-            puissance: 3,
-            abonnement: 10.11,
-            bleu: {
-                prixKwhHP: 27.29,
-                prixKwhHC: 17.38
-            },
-            weekend: {
-                prixKwhHP: 17.38,
-                prixKwhHC: 17.38
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 13.78,
-            bleu: {
-                prixKwhHP: 27.29,
-                prixKwhHC: 17.38
-            },
-            weekend: {
-                prixKwhHP: 17.38,
-                prixKwhHC: 17.38
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 17.49,
-            bleu: {
-                prixKwhHP: 27.29,
-                prixKwhHC: 17.38
-            },
-            weekend: {
-                prixKwhHP: 17.38,
-                prixKwhHC: 17.38
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 21.12,
-            bleu: {
-                prixKwhHP: 27.29,
-                prixKwhHC: 17.38
-            },
-            weekend: {
-                prixKwhHP: 17.38,
-                prixKwhHC: 17.38
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 24.57,
-            bleu: {
-                prixKwhHP: 27.29,
-                prixKwhHC: 17.38
-            },
-            weekend: {
-                prixKwhHP: 17.38,
-                prixKwhHC: 17.38
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 28.00,
-            bleu: {
-                prixKwhHP: 27.29,
-                prixKwhHC: 17.38
-            },
-            weekend: {
-                prixKwhHP: 17.38,
-                prixKwhHC: 17.38
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 35.19,
-            bleu: {
-                prixKwhHP: 27.29,
-                prixKwhHC: 17.38
-            },
-            weekend: {
-                prixKwhHP: 17.38,
-                prixKwhHC: 17.38
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 41.75,
-            bleu: {
-                prixKwhHP: 27.29,
-                prixKwhHC: 17.38
-            },
-            weekend: {
-                prixKwhHP: 17.38,
-                prixKwhHC: 17.38
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 48.37,
-            bleu: {
-                prixKwhHP: 27.29,
-                prixKwhHC: 17.38
-            },
-            weekend: {
-                prixKwhHP: 17.38,
-                prixKwhHC: 17.38
-            }
-        }],
+    { puissance: 3, abonnement: 10.11 },
+    { puissance: 6, abonnement: 13.78 },
+    { puissance: 9, abonnement: 17.49 },
+    { puissance: 12, abonnement: 21.12 },
+    { puissance: 15, abonnement: 24.57 },
+    { puissance: 18, abonnement: 28.00 },
+    { puissance: 24, abonnement: 35.19 },
+    { puissance: 30, abonnement: 41.75 },
+    { puissance: 36, abonnement: 48.37 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 27.29, prixKwhHC: 17.38 }
+})),
+
     hc: [{
         start: {hour:22, minute:0},
         end: {hour:24, minute:0}

--- a/scripts/tarifs/sowee/fixe3ans_HC.js
+++ b/scripts/tarifs/sowee/fixe3ans_HC.js
@@ -5,70 +5,19 @@ abonnements.push({
     subscription_url: "https://www.sowee.fr/tarifs-contrats-energies-gaz-electricite",
     price_url: "https://www.sowee.fr/s3fs-public/Grille_de_prix_Elec_Prix_fixe_3_ans_Fevrier_2024.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 13.39,
-            bleu: {
-                prixKwhHP: 23.57,
-                prixKwhHC: 18.13
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 17.00,
-            bleu: {
-                prixKwhHP: 23.57,
-                prixKwhHC: 18.13
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.52,
-            bleu: {
-                prixKwhHP: 23.57,
-                prixKwhHC: 18.13
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.89,
-            bleu: {
-                prixKwhHP: 23.57,
-                prixKwhHC: 18.13
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 27.22,
-            bleu: {
-                prixKwhHP: 23.57,
-                prixKwhHC: 18.13
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 34.21,
-            bleu: {
-                prixKwhHP: 23.57,
-                prixKwhHC: 18.13
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 40.60,
-            bleu: {
-                prixKwhHP: 23.57,
-                prixKwhHC: 18.13
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 47.04,
-            bleu: {
-                prixKwhHP: 23.57,
-                prixKwhHC: 18.13
-            }
-        }],
+    { puissance: 6, abonnement: 13.39 },
+    { puissance: 9, abonnement: 17.00 },
+    { puissance: 12, abonnement: 20.52 },
+    { puissance: 15, abonnement: 23.89 },
+    { puissance: 18, abonnement: 27.22 },
+    { puissance: 24, abonnement: 34.21 },
+    { puissance: 30, abonnement: 40.60 },
+    { puissance: 36, abonnement: 47.04 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 23.57, prixKwhHC: 18.13 }
+})),
+
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,

--- a/scripts/tarifs/sowee/fixe3ans_base.js
+++ b/scripts/tarifs/sowee/fixe3ans_base.js
@@ -5,69 +5,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://www.sowee.fr/tarifs-contrats-energies-gaz-electricite",
         price_url: "https://www.sowee.fr/s3fs-public/Grille_de_prix_Elec_Prix_fixe_3_ans_Fevrier_2024.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.69,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.72,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.96,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.27,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.36,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.42,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.20,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 38.01,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.82,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 9.69 },
+    { puissance: 6, abonnement: 12.72 },
+    { puissance: 9, abonnement: 15.96 },
+    { puissance: 12, abonnement: 19.27 },
+    { puissance: 15, abonnement: 22.36 },
+    { puissance: 18, abonnement: 25.42 },
+    { puissance: 24, abonnement: 32.20 },
+    { puissance: 30, abonnement: 38.01 },
+    { puissance: 36, abonnement: 44.82 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 21.77 }
+})),
+
         hc: [{
             start: { hour: 0, minute: 0 },
             end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/sowee/optim_HC.js
+++ b/scripts/tarifs/sowee/optim_HC.js
@@ -5,70 +5,19 @@ abonnements.push({
     subscription_url: "https://www.sowee.fr/tarifs-contrats-energies-gaz-electricite",
     price_url: "https://www.sowee.fr/s3fs-public/Grille_de_prix_Elec_Optim_Fevrier_2024.pdf",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 14.46,
-            bleu: {
-                prixKwhHP: 29.33,
-                prixKwhHC: 22.40
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 18.35,
-            bleu: {
-                prixKwhHP: 29.33,
-                prixKwhHC: 22.40
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 22.13,
-            bleu: {
-                prixKwhHP: 29.33,
-                prixKwhHC: 22.40
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 25.75,
-            bleu: {
-                prixKwhHP: 29.33,
-                prixKwhHC: 22.40
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 29.34,
-            bleu: {
-                prixKwhHP: 29.33,
-                prixKwhHC: 22.40
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 36.86,
-            bleu: {
-                prixKwhHP: 29.33,
-                prixKwhHC: 22.40
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 43.72,
-            bleu: {
-                prixKwhHP: 29.33,
-                prixKwhHC: 22.40
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 50.64,
-            bleu: {
-                prixKwhHP: 29.33,
-                prixKwhHC: 22.40
-            }
-        }],
+    { puissance: 6, abonnement: 14.46 },
+    { puissance: 9, abonnement: 18.35 },
+    { puissance: 12, abonnement: 22.13 },
+    { puissance: 15, abonnement: 25.75 },
+    { puissance: 18, abonnement: 29.34 },
+    { puissance: 24, abonnement: 36.86 },
+    { puissance: 30, abonnement: 43.72 },
+    { puissance: 36, abonnement: 50.64 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 29.33, prixKwhHC: 22.40 }
+})),
+
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,

--- a/scripts/tarifs/sowee/optim_base.js
+++ b/scripts/tarifs/sowee/optim_base.js
@@ -5,69 +5,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://www.sowee.fr/tarifs-contrats-energies-gaz-electricite",
         price_url: "https://www.sowee.fr/s3fs-public/Grille_de_prix_Elec_Optim_Fevrier_2024.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 10.15,
-            bleu: {
-                prixKwhHC: 26.41
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 13.32,
-            bleu: {
-                prixKwhHC: 26.41
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.71,
-            bleu: {
-                prixKwhHC: 26.41
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.17,
-            bleu: {
-                prixKwhHC: 26.41
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.39,
-            bleu: {
-                prixKwhHC: 26.41
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.59,
-            bleu: {
-                prixKwhHC: 26.41
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.68,
-            bleu: {
-                prixKwhHC: 26.41
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.75,
-            bleu: {
-                prixKwhHC: 26.41
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 46.87,
-            bleu: {
-                prixKwhHC: 26.41
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 10.15 },
+    { puissance: 6, abonnement: 13.32 },
+    { puissance: 9, abonnement: 16.71 },
+    { puissance: 12, abonnement: 20.17 },
+    { puissance: 15, abonnement: 23.39 },
+    { puissance: 18, abonnement: 26.59 },
+    { puissance: 24, abonnement: 33.68 },
+    { puissance: 30, abonnement: 39.75 },
+    { puissance: 36, abonnement: 46.87 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 26.41 }
+})),
+
         hc: [{
             start: { hour: 0, minute: 0 },
             end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/switch/base.js
+++ b/scripts/tarifs/switch/base.js
@@ -1,84 +1,28 @@
-abonnements.push(
-    {
-        name: "Switch - Base",
-        offer_type: "Marché",
-        lastUpdate: "2024-02-01",
-        subscription_url: "https://www.chezswitch.fr/offre-energie/#/",
-        price_url: "https://api.chezswitch.fr/docs/2024.02.01_Grille_tarifaire_des_offres_delectricite.pdf?v=30",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.38,
-            bleu: {
-                prixKwhHC: 19.95
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.27,
-            bleu: {
-                prixKwhHC: 19.95
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.38,
-            bleu: {
-                prixKwhHC: 19.95
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 18.55,
-            bleu: {
-                prixKwhHC: 19.95
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 21.51,
-            bleu: {
-                prixKwhHC: 19.95
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 24.45,
-            bleu: {
-                prixKwhHC: 19.95
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 30.95,
-            bleu: {
-                prixKwhHC: 19.95
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 36.50,
-            bleu: {
-                prixKwhHC: 19.95
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 43.03,
-            bleu: {
-                prixKwhHC: 19.95
-            }
-        }],
-        hc: [{
-            start: { hour: 0, minute: 0 },
-            end: { hour: 24, minute: 0 }
-        }],
-        hasHCCustom: false,
-        hasSpecialDaysCustom: false,
-        specialDays: [],
-        getDayType: function (day) {
-            let dayType = "bleu";
-            return dayType;
-        }
+abonnements.push({
+    name: "Switch - Base",
+    offer_type: "Marché",
+    lastUpdate: "2024-02-01",
+    subscription_url: "https://www.chezswitch.fr/offre-energie/#/",
+    price_url: "https://api.chezswitch.fr/docs/2024.02.01_Grille_tarifaire_des_offres_delectricite.pdf?v=30",
+    prices: [
+        { puissance: 3, abonnement: 9.38 },
+        { puissance: 6, abonnement: 12.27 },
+        { puissance: 9, abonnement: 15.38 },
+        { puissance: 12, abonnement: 18.55 },
+        { puissance: 15, abonnement: 21.51 },
+        { puissance: 18, abonnement: 24.45 },
+        { puissance: 24, abonnement: 30.95 },
+        { puissance: 30, abonnement: 36.50 },
+        { puissance: 36, abonnement: 43.03 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHC: 19.95 }
+    })),
+    hc: [{ start: { hour: 0, minute: 0 }, end: { hour: 24, minute: 0 } }],
+    hasHCCustom: false,
+    hasSpecialDaysCustom: false,
+    specialDays: [],
+    getDayType: function (day) {
+        return "bleu";
     }
-);
-
+});

--- a/scripts/tarifs/switch/baseHC.js
+++ b/scripts/tarifs/switch/baseHC.js
@@ -5,76 +5,23 @@ abonnements.push({
     subscription_url: "https://www.chezswitch.fr/offre-energie/",
     price_url: "https://api.chezswitch.fr/docs/2024.02.01_Grille_tarifaire_des_offres_delectricite.pdf?v=30",
     prices: [
-        {
-            puissance: 6,
-            abonnement: 12.67,
-            bleu: {
-                prixKwhHP: 21.36,
-                prixKwhHC: 16.50
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.01,
-            bleu: {
-                prixKwhHP: 21.36,
-                prixKwhHC: 16.50
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.26,
-            bleu: {
-                prixKwhHP: 21.36,
-                prixKwhHC: 16.50
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.36,
-            bleu: {
-                prixKwhHP: 21.36,
-                prixKwhHC: 16.50
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.43,
-            bleu: {
-                prixKwhHP: 21.36,
-                prixKwhHC: 16.50
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 31.88,
-            bleu: {
-                prixKwhHP: 21.36,
-                prixKwhHC: 16.50
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.75,
-            bleu: {
-                prixKwhHP: 21.36,
-                prixKwhHC: 16.50
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 43.66,
-            bleu: {
-                prixKwhHP: 21.36,
-                prixKwhHC: 16.50
-            }
-        }],
+        { puissance: 6, abonnement: 12.67 },
+        { puissance: 9, abonnement: 16.01 },
+        { puissance: 12, abonnement: 19.26 },
+        { puissance: 15, abonnement: 22.36 },
+        { puissance: 18, abonnement: 25.43 },
+        { puissance: 24, abonnement: 31.88 },
+        { puissance: 30, abonnement: 37.75 },
+        { puissance: 36, abonnement: 43.66 }
+    ].map(item => ({
+        ...item,
+        bleu: { prixKwhHP: 21.36, prixKwhHC: 16.50 }
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,
     specialDays: [],
     getDayType: function (day) {
-        let dayType = "bleu";
-        return dayType;
+        return "bleu";
     }
 });

--- a/scripts/tarifs/total/heuresEco.js
+++ b/scripts/tarifs/total/heuresEco.js
@@ -4,69 +4,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://www.totalenergies.fr/particuliers/electricite/offres-d-electricite/offre-heures-eco-electricite",
         price_url: "https://www.totalenergies.fr/fileadmin/Digital/Groupe/PDF/Documents_contractuels/Particuliers/Tarifs_TotalEnergies/fr/grille-tarifaire-heures-eco-particuliers.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.47,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.44,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.63,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 18.89,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 21.92,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.25,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.05,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.84,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.66,
-            bleu: {
-                prixKwhHC: 25.16
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 9.47 },
+    { puissance: 6, abonnement: 12.44 },
+    { puissance: 9, abonnement: 15.63 },
+    { puissance: 12, abonnement: 18.89 },
+    { puissance: 15, abonnement: 21.92 },
+    { puissance: 18, abonnement: 25.25 },
+    { puissance: 24, abonnement: 32.05 },
+    { puissance: 30, abonnement: 37.84 },
+    { puissance: 36, abonnement: 44.66 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 25.16 }
+})),
+
         hc: [{
             start: { hour: 0, minute: 0 },
             end: { hour: 24, minute: 0 }

--- a/scripts/tarifs/total/heuresEcoHC.js
+++ b/scripts/tarifs/total/heuresEcoHC.js
@@ -5,70 +5,19 @@ abonnements.push(
         subscription_url: "https://www.totalenergies.fr/particuliers/electricite/offres-d-electricite/offre-heures-eco-electricite",
         price_url: "https://www.totalenergies.fr/fileadmin/Digital/Groupe/PDF/Documents_contractuels/Particuliers/Tarifs_TotalEnergies/fr/grille-tarifaire-heures-eco-particuliers.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 12.85,
-            bleu: {
-                prixKwhHP: 27.95,
-                prixKwhHC: 19.27
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.55,
-            bleu: {
-                prixKwhHP: 27.95,
-                prixKwhHC: 19.27
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 20.36,
-            bleu: {
-                prixKwhHP: 27.95,
-                prixKwhHC: 19.27
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.73,
-            bleu: {
-                prixKwhHP: 27.95,
-                prixKwhHC: 19.27
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.48,
-            bleu: {
-                prixKwhHP: 27.95,
-                prixKwhHC: 19.27
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.28,
-            bleu: {
-                prixKwhHP: 27.95,
-                prixKwhHC: 19.27
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.46,
-            bleu: {
-                prixKwhHP: 27.95,
-                prixKwhHC: 19.27
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.63,
-            bleu: {
-                prixKwhHP: 27.95,
-                prixKwhHC: 19.27
-            }
-        }],
+    { puissance: 6, abonnement: 12.85 },
+    { puissance: 9, abonnement: 16.55 },
+    { puissance: 12, abonnement: 20.36 },
+    { puissance: 15, abonnement: 23.73 },
+    { puissance: 18, abonnement: 26.48 },
+    { puissance: 24, abonnement: 33.28 },
+    { puissance: 30, abonnement: 39.46 },
+    { puissance: 36, abonnement: 44.63 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 27.95, prixKwhHC: 19.27 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/total/offreStandardFixe.js
+++ b/scripts/tarifs/total/offreStandardFixe.js
@@ -4,69 +4,21 @@ abonnements.push(
         lastUpdate: "2024-03-26",
         subscription_url: "https://www.totalenergies.fr/particuliers/electricite/offres-d-electricite/offre-standard-fixe-electricite",
         price_url: "https://www.totalenergies.fr/fileadmin/Digital/Groupe/PDF/Documents_contractuels/Particuliers/Tarifs_TotalEnergies/fr/grille-tarifaire-standard-fixe-particuliers.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.51,
-            bleu: {
-                prixKwhHC: 21.32
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.50,
-            bleu: {
-                prixKwhHC: 21.32
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.75,
-            bleu: {
-                prixKwhHC: 21.32
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.08,
-            bleu: {
-                prixKwhHC: 21.32
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.14,
-            bleu: {
-                prixKwhHC: 21.32
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.17,
-            bleu: {
-                prixKwhHC: 21.32
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.05,
-            bleu: {
-                prixKwhHC: 21.32
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 37.71,
-            bleu: {
-                prixKwhHC: 21.32
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.62,
-            bleu: {
-                prixKwhHC: 21.32
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 9.51 },
+    { puissance: 6, abonnement: 12.50 },
+    { puissance: 9, abonnement: 15.75 },
+    { puissance: 12, abonnement: 19.08 },
+    { puissance: 15, abonnement: 22.14 },
+    { puissance: 18, abonnement: 25.17 },
+    { puissance: 24, abonnement: 32.05 },
+    { puissance: 30, abonnement: 37.71 },
+    { puissance: 36, abonnement: 44.62 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 21.32 }
+})),
+
         hc: [{
             start: {hour:0, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/total/offreStandardFixeHC.js
+++ b/scripts/tarifs/total/offreStandardFixeHC.js
@@ -5,70 +5,19 @@ abonnements.push(
         subscription_url: "https://www.totalenergies.fr/particuliers/electricite/offres-d-electricite/offre-standard-fixe-electricite",
         price_url: "https://www.totalenergies.fr/fileadmin/Digital/Groupe/PDF/Documents_contractuels/Particuliers/Tarifs_TotalEnergies/fr/grille-tarifaire-standard-fixe-particuliers.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 13.00,
-            bleu: {
-                prixKwhHP: 22.88,
-                prixKwhHC: 17.51
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.54,
-            bleu: {
-                prixKwhHP: 22.88,
-                prixKwhHC: 17.51
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.97,
-            bleu: {
-                prixKwhHP: 22.88,
-                prixKwhHC: 17.51
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.21,
-            bleu: {
-                prixKwhHP: 22.88,
-                prixKwhHC: 17.51
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.41,
-            bleu: {
-                prixKwhHP: 22.88,
-                prixKwhHC: 17.51
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.22,
-            bleu: {
-                prixKwhHP: 22.88,
-                prixKwhHC: 17.51
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.27,
-            bleu: {
-                prixKwhHP: 22.88,
-                prixKwhHC: 17.51
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.40,
-            bleu: {
-                prixKwhHP: 22.88,
-                prixKwhHC: 17.51
-            }
-        }],
+    { puissance: 6, abonnement: 13.00 },
+    { puissance: 9, abonnement: 16.54 },
+    { puissance: 12, abonnement: 19.97 },
+    { puissance: 15, abonnement: 23.21 },
+    { puissance: 18, abonnement: 26.41 },
+    { puissance: 24, abonnement: 33.22 },
+    { puissance: 30, abonnement: 39.27 },
+    { puissance: 36, abonnement: 45.40 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 22.88, prixKwhHC: 17.51 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/total/offreVerteFixe.js
+++ b/scripts/tarifs/total/offreVerteFixe.js
@@ -4,69 +4,21 @@ abonnements.push(
         lastUpdate: "2024-02-01",
         subscription_url: "https://www.totalenergies.fr/particuliers/electricite/offres-d-electricite/offre-heures-eco-electricite",
         price_url: "https://www.totalenergies.fr/fileadmin/Digital/Documents-contractuels/GT/grille-tarifaire-verte-fixe-particuliers.pdf",
-        prices: [{
-            puissance: 3,
-            abonnement: 9.51,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 6,
-            abonnement: 12.50,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 15.75,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.08,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 22.14,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 25.17,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 32.05,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 30.71,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 44.62,
-            bleu: {
-                prixKwhHC: 21.77
-            }
-        }],
+        prices: [
+    { puissance: 3, abonnement: 9.51 },
+    { puissance: 6, abonnement: 12.50 },
+    { puissance: 9, abonnement: 15.75 },
+    { puissance: 12, abonnement: 19.08 },
+    { puissance: 15, abonnement: 22.14 },
+    { puissance: 18, abonnement: 25.17 },
+    { puissance: 24, abonnement: 32.05 },
+    { puissance: 30, abonnement: 30.71 },
+    { puissance: 36, abonnement: 44.62 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHC: 21.77 }
+})),
+
         hc: [{
             start: {hour:0, minute:0},
             end: {hour:24, minute:0}

--- a/scripts/tarifs/total/offreVerteFixeHC.js
+++ b/scripts/tarifs/total/offreVerteFixeHC.js
@@ -5,70 +5,19 @@ abonnements.push(
         subscription_url: "https://www.totalenergies.fr/particuliers/electricite/offres-d-electricite/offre-heures-eco-electricite",
         price_url: "https://www.totalenergies.fr/fileadmin/Digital/Documents-contractuels/GT/grille-tarifaire-verte-fixe-particuliers.pdf",
         prices: [
-        {
-            puissance: 6,
-            abonnement: 13.00,
-            bleu: {
-                prixKwhHP: 23.34,
-                prixKwhHC: 17.96
-            }
-        },
-        {
-            puissance: 9,
-            abonnement: 16.54,
-            bleu: {
-                prixKwhHP: 23.34,
-                prixKwhHC: 17.96
-            }
-        },
-        {
-            puissance: 12,
-            abonnement: 19.97,
-            bleu: {
-                prixKwhHP: 23.34,
-                prixKwhHC: 17.96
-            }
-        },
-        {
-            puissance: 15,
-            abonnement: 23.21,
-            bleu: {
-                prixKwhHP: 23.34,
-                prixKwhHC: 17.96
-            }
-        },
-        {
-            puissance: 18,
-            abonnement: 26.41,
-            bleu: {
-                prixKwhHP: 23.34,
-                prixKwhHC: 17.96
-            }
-        },
-        {
-            puissance: 24,
-            abonnement: 33.22,
-            bleu: {
-                prixKwhHP: 23.34,
-                prixKwhHC: 17.96
-            }
-        },
-        {
-            puissance: 30,
-            abonnement: 39.27,
-            bleu: {
-                prixKwhHP: 23.34,
-                prixKwhHC: 17.96
-            }
-        },
-        {
-            puissance: 36,
-            abonnement: 45.40,
-            bleu: {
-                prixKwhHP: 23.34,
-                prixKwhHC: 17.96
-            }
-        }],
+    { puissance: 6, abonnement: 13.00 },
+    { puissance: 9, abonnement: 16.54 },
+    { puissance: 12, abonnement: 19.97 },
+    { puissance: 15, abonnement: 23.21 },
+    { puissance: 18, abonnement: 26.41 },
+    { puissance: 24, abonnement: 33.22 },
+    { puissance: 30, abonnement: 39.27 },
+    { puissance: 36, abonnement: 45.40 },
+].map(item => ({
+    ...item,
+    bleu: { prixKwhHP: 23.34, prixKwhHC: 17.96 }
+})),
+
         hc: [{
             start: {hour:22, minute:0},
             end: {hour:24, minute:0}


### PR DESCRIPTION
Tous les tarifs (sauf 2) ont le même prix au kWh quelle que soit la puissance. Ce changement factorise tout les tarifs, pour permettre une meilleure lisibilité et des changements de tarifs plus simples (pas besoin de changer le prix du kWh pour chaque puissance).

(to be rebased once #123 is merged (or not :-) )