### PR TITLE
Mise à jour des tarifs offres de marché d'EDF au 14 mars 2025

### DIFF
--- a/scripts/tarifs/edf/vert.js
+++ b/scripts/tarifs/edf/vert.js
@@ -2,24 +2,24 @@ abonnements.push(
     {
         name: "EDF - Vert Electrique",
         offer_type: "Marché",
-        lastUpdate: "2025-02-01",
+        lastUpdate: "2025-03-14",
         isCommunity: false,
         subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique.html",
         price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique.pdf",
         prices: [
-            { puissance: 3, abonnement: 9.77 },
-            { puissance: 6, abonnement: 12.80 },
-            { puissance: 9, abonnement: 16.05 },
-            { puissance: 12, abonnement: 19.37 },
-            { puissance: 15, abonnement: 22.46 },
-            { puissance: 18, abonnement: 25.54 },
-            { puissance: 24, abonnement: 32.34 },
-            { puissance: 30, abonnement: 38.14 },
-            { puissance: 36, abonnement: 44.98 }
+            { puissance: 3, abonnement: 10.41 },
+            { puissance: 6, abonnement: 13.72 },
+            { puissance: 9, abonnement: 17.27 },
+            { puissance: 12, abonnement: 20.86 },
+            { puissance: 15, abonnement: 24.20 },
+            { puissance: 18, abonnement: 27.39 },
+            { puissance: 24, abonnement: 34.68 },
+            { puissance: 30, abonnement: 41.99 },
+            { puissance: 36, abonnement: 48.39 }
         ].map(item => ({
             ...item,
             bleu: {
-                prixKwhHC: 25.75
+                prixKwhHC: 19.36
             }
         })),
         hc: [{
@@ -39,26 +39,26 @@ abonnements.push(
 abonnements.push({
     name: "EDF - Vert Electrique Heures Creuses",
     offer_type: "Marché",
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique.pdf",
     prices: [
-        { puissance: 6, abonnement: 13.21 },
-        { puissance: 9, abonnement: 17.01 },
-        { puissance: 12, abonnement: 20.51 },
-        { puissance: 15, abonnement: 23.34 },
-        { puissance: 18, abonnement: 26.55 },
-        { puissance: 24, abonnement: 33.30 },
-        { puissance: 30, abonnement: 39.43 },
-        { puissance: 36, abonnement: 45.62 }
+        { puissance: 6, abonnement: 14.04 },
+        { puissance: 9, abonnement: 18.01 },
+        { puissance: 12, abonnement: 21.69 },
+        { puissance: 15, abonnement: 24.64 },
+        { puissance: 18, abonnement: 28.11 },
+        { puissance: 24, abonnement: 35.40 },
+        { puissance: 30, abonnement: 41.96 },
+        { puissance: 36, abonnement: 48.72 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHP: 27.71,
-            prixKwhHC: 21.38
+            prixKwhHP: 20.76,
+            prixKwhHC: 16.26
         }
-    })),    
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,

--- a/scripts/tarifs/edf/vertAuto.js
+++ b/scripts/tarifs/edf/vertAuto.js
@@ -1,24 +1,24 @@
 abonnements.push({
     name: "EDF - Vert Electrique Auto",
     offer_type: "Marché",
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-auto.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-auto.pdf",
     prices: [
-        { puissance: 6, abonnement: 13.42 },
-        { puissance: 9, abonnement: 17.01 },
-        { puissance: 12, abonnement: 20.51 },
-        { puissance: 15, abonnement: 23.86 },
-        { puissance: 18, abonnement: 27.17 },
-        { puissance: 24, abonnement: 34.13 },
-        { puissance: 30, abonnement: 40.47 },
-        { puissance: 36, abonnement: 45.62 }
+        { puissance: 6, abonnement: 14.24 },
+        { puissance: 9, abonnement: 18.01 },
+        { puissance: 12, abonnement: 21.69 },
+        { puissance: 15, abonnement: 25.16 },
+        { puissance: 18, abonnement: 28.74 },
+        { puissance: 24, abonnement: 36.23 },
+        { puissance: 30, abonnement: 43.00 },
+        { puissance: 36, abonnement: 48.72 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHP: 31.06,
-            prixKwhHC: 17.56
+            prixKwhHP: 22.86,
+            prixKwhHC: 13.45
         }
     })),
     hc: [],

--- a/scripts/tarifs/edf/vertRegional.js
+++ b/scripts/tarifs/edf/vertRegional.js
@@ -1,57 +1,57 @@
 abonnements.push({
     name: "EDF - Vert Electrique Régional",
     offer_type: "Marché",
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-regional.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-regional.pdf",
     prices: [
         {
-            puissance: 6, abonnement: 12.80,
+            puissance: 6, abonnement: 13.72,
             bleu: {
-                prixKwhHC: 26.36
+                prixKwhHC: 19.61
             }
         },
         {
-            puissance: 9, abonnement: 16.05,
+            puissance: 9, abonnement: 17.27,
             bleu: {
-                prixKwhHC: 26.40
+                prixKwhHC: 19.68
             }
         },
         {
-            puissance: 12, abonnement: 19.37,
+            puissance: 12, abonnement: 20.86,
             bleu: {
-                prixKwhHC: 26.40
+                prixKwhHC: 19.68
             }
         },
         {
-            puissance: 15, abonnement: 22.46,
+            puissance: 15, abonnement: 24.20,
             bleu: {
-                prixKwhHC: 26.40
+                prixKwhHC: 19.68
             }
         },
         {
-            puissance: 18, abonnement: 25.54,
+            puissance: 18, abonnement: 27.39,
             bleu: {
-                prixKwhHC: 26.40
+                prixKwhHC: 19.68
             }
         },
         {
-            puissance: 24, abonnement: 32.34,
+            puissance: 24, abonnement: 34.68,
             bleu: {
-                prixKwhHC: 26.40
+                prixKwhHC: 19.68
             }
         },
         {
-            puissance: 30, abonnement: 38.14,
+            puissance: 30, abonnement: 41.99,
             bleu: {
-                prixKwhHC: 26.40
+                prixKwhHC: 19.68
             }
         },
         {
-            puissance: 36, abonnement: 46.23,
+            puissance: 36, abonnement: 49.64,
             bleu: {
-                prixKwhHC: 26.40
+                prixKwhHC: 19.68
             }
         }
     ].map(item => ({
@@ -74,26 +74,26 @@ abonnements.push({
 abonnements.push({
     name: "EDF - Vert Electrique Régional Heures Creuses",
     offer_type: "Marché",
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-regional.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-regional.pdf",
     prices: [
-        { puissance: 6, abonnement: 13.21 },
-        { puissance: 9, abonnement: 17.01 },
-        { puissance: 12, abonnement: 20.51 },
-        { puissance: 15, abonnement: 23.86 },
-        { puissance: 18, abonnement: 26.55 },
-        { puissance: 24, abonnement: 33.30 },
-        { puissance: 30, abonnement: 39.43 },
-        { puissance: 36, abonnement: 45.62 }
+        { puissance: 6, abonnement: 14.04 },
+        { puissance: 9, abonnement: 18.01 },
+        { puissance: 12, abonnement: 21.69 },
+        { puissance: 15, abonnement: 25.16 },
+        { puissance: 18, abonnement: 28.11 },
+        { puissance: 24, abonnement: 35.40 },
+        { puissance: 30, abonnement: 41.96 },
+        { puissance: 36, abonnement: 48.72 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHP: 29.22,
-            prixKwhHC: 20.56
+            prixKwhHP: 21.30,
+            prixKwhHC: 16.07
         }
-    })), 
+    })),
     hc: [],
     hasHCCustom: true,
     hasSpecialDaysCustom: false,

--- a/scripts/tarifs/edf/vertWeekEnd.js
+++ b/scripts/tarifs/edf/vertWeekEnd.js
@@ -1,26 +1,26 @@
 abonnements.push({
     name: "EDF - Vert Electrique Week-End",
     offer_type: "Marché",
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-weekend.pdf",
     prices: [
-        { puissance: 6, abonnement: 12.80 },
-        { puissance: 9, abonnement: 16.05 },
-        { puissance: 12, abonnement: 19.37 },
-        { puissance: 15, abonnement: 22.46 },
-        { puissance: 18, abonnement: 25.54 },
-        { puissance: 24, abonnement: 32.34 },
-        { puissance: 30, abonnement: 39.19 },
-        { puissance: 36, abonnement: 44.98 }
+        { puissance: 6, abonnement: 13.72 },
+        { puissance: 9, abonnement: 17.27 },
+        { puissance: 12, abonnement: 20.86 },
+        { puissance: 15, abonnement: 24.20 },
+        { puissance: 18, abonnement: 27.39 },
+        { puissance: 24, abonnement: 34.68 },
+        { puissance: 30, abonnement: 43.04 },
+        { puissance: 36, abonnement: 48.39 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHC: 28.10
+            prixKwhHC: 21.07
         },
         weekend: {
-            prixKwhHC: 20.89
+            prixKwhHC: 15.96
         }
     })),
     hc: [{
@@ -47,28 +47,28 @@ abonnements.push({
 abonnements.push({
     name: "EDF - Vert Electrique Week-End Heures Creuses",
     offer_type: "Marché",
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-verte/vert-electrique-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-weekend.pdf",
     prices: [
-        { puissance: 6, abonnement: 13.21 },
-        { puissance: 9, abonnement: 17.01 },
-        { puissance: 12, abonnement: 20.51 },
-        { puissance: 15, abonnement: 23.86 },
-        { puissance: 18, abonnement: 27.17 },
-        { puissance: 24, abonnement: 34.13 },
-        { puissance: 30, abonnement: 40.47 },
-        { puissance: 36, abonnement: 45.62 }
+        { puissance: 6, abonnement: 14.04 },
+        { puissance: 9, abonnement: 18.01 },
+        { puissance: 12, abonnement: 21.69 },
+        { puissance: 15, abonnement: 25.16 },
+        { puissance: 18, abonnement: 28.74 },
+        { puissance: 24, abonnement: 36.23 },
+        { puissance: 30, abonnement: 43.00 },
+        { puissance: 36, abonnement: 48.72 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHP: 29.69,
-            prixKwhHC: 22.00
+            prixKwhHP: 22.15,
+            prixKwhHC: 16.72
         },
         weekend: {
-            prixKwhHP: 22.00,
-            prixKwhHC: 22.00
+            prixKwhHP: 16.72,
+            prixKwhHC: 16.72
         }
     })),
     hc: [],

--- a/scripts/tarifs/edf/zenWeekEnd.js
+++ b/scripts/tarifs/edf/zenWeekEnd.js
@@ -2,27 +2,27 @@ abonnements.push({
     name: "EDF - Zen Week-End",
     offer_type: "Marché",
     hasSpecialDaysCustom: false,
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end.pdf",
     prices: [
-        { puissance: 3, abonnement: 9.77 },
-        { puissance: 6, abonnement: 12.80 },
-        { puissance: 9, abonnement: 16.05 },
-        { puissance: 12, abonnement: 19.79 },
-        { puissance: 15, abonnement: 22.46 },
-        { puissance: 18, abonnement: 25.54 },
-        { puissance: 24, abonnement: 33.17 },
-        { puissance: 30, abonnement: 38.14 },
-        { puissance: 36, abonnement: 44.98 }
+        { puissance: 3, abonnement: 10.41 },
+        { puissance: 6, abonnement: 13.72 },
+        { puissance: 9, abonnement: 17.27 },
+        { puissance: 12, abonnement: 21.27 },
+        { puissance: 15, abonnement: 24.20 },
+        { puissance: 18, abonnement: 27.39 },
+        { puissance: 24, abonnement: 35.51 },
+        { puissance: 30, abonnement: 41.99 },
+        { puissance: 36, abonnement: 48.39 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHC: 28.04
+            prixKwhHC: 20.94,
         },
         weekend: {
-            prixKwhHC: 20.84
+            prixKwhHC: 15.88
         }
     })),
     hc: [{
@@ -49,30 +49,30 @@ abonnements.push({
 abonnements.push({
     name: "EDF - Zen Week-End HC",
     offer_type: "Marché",
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end.pdf",
-    prices: [        
-        { puissance: 6, abonnement: 13.21 },
-        { puissance: 9, abonnement: 17.01 },
-        { puissance: 12, abonnement: 20.51 },
-        { puissance: 15, abonnement: 23.86 },
-        { puissance: 18, abonnement: 27.17 },
-        { puissance: 24, abonnement: 34.13 },
-        { puissance: 30, abonnement: 40.47 },
-        { puissance: 36, abonnement: 46.87 }
+    prices: [
+        { puissance: 6, abonnement: 14.04 },
+        { puissance: 9, abonnement: 18.01 },
+        { puissance: 12, abonnement: 21.69 },
+        { puissance: 15, abonnement: 25.16 },
+        { puissance: 18, abonnement: 28.74 },
+        { puissance: 24, abonnement: 36.23 },
+        { puissance: 30, abonnement: 43.00 },
+        { puissance: 36, abonnement: 49.97 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHP: 29.60,
-            prixKwhHC: 21.94
+            prixKwhHP: 22.08,
+            prixKwhHC: 16.67
         },
         weekend: {
-            prixKwhHP: 21.94,
-            prixKwhHC: 21.94
+            prixKwhHP: 16.67,
+            prixKwhHC: 16.67
         }
-    })),    
+    })),
     hc: [{
         start: { hour: 22, minute: 0 },
         end: { hour: 24, minute: 0 }
@@ -101,28 +101,28 @@ abonnements.push({
 abonnements.push({
     name: "EDF - Zen Week-End Option Flex",
     offer_type: "Marché",
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-flex.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end.pdf",
     prices: [
-        { puissance: 6, abonnement: 13.21 },
-        { puissance: 9, abonnement: 17.01 },
-        { puissance: 12, abonnement: 20.51 },
-        { puissance: 15, abonnement: 23.86 },
-        { puissance: 18, abonnement: 27.17 },
-        { puissance: 24, abonnement: 34.13 },
-        { puissance: 30, abonnement: 40.47 },
-        { puissance: 36, abonnement: 46.87 }
+        { puissance: 6, abonnement: 14.04 },
+        { puissance: 9, abonnement: 18.01 },
+        { puissance: 12, abonnement: 21.69 },
+        { puissance: 15, abonnement: 25.16 },
+        { puissance: 18, abonnement: 28.74 },
+        { puissance: 24, abonnement: 36.23 },
+        { puissance: 30, abonnement: 43.00 },
+        { puissance: 36, abonnement: 49.97 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHC: 19.48,
-            prixKwhHP: 28.52
+            prixKwhHC: 15.66,
+            prixKwhHP: 21.46
         },
         sobriete: {
-            prixKwhHC: 28.52,
-            prixKwhHP: 77.15
+            prixKwhHC: 21.46,
+            prixKwhHP: 73.69
         }
     })),
     hc: [{

--- a/scripts/tarifs/edf/zenWeekEndPlus.js
+++ b/scripts/tarifs/edf/zenWeekEndPlus.js
@@ -1,26 +1,26 @@
 abonnements.push({
     name: "EDF - Zen Week-End Plus",
     offer_type: "Marché",
-    lastUpdate: "2025-02-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end-plus.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end-plus.pdf",
-    prices: [        
-        { puissance: 6, abonnement: 12.80 },
-        { puissance: 9, abonnement: 16.37 },
-        { puissance: 12, abonnement: 19.79 },
-        { puissance: 15, abonnement: 22.46 },
-        { puissance: 18, abonnement: 26.16 },
-        { puissance: 24, abonnement: 33.17 },
-        { puissance: 30, abonnement: 38.14 },
-        { puissance: 36, abonnement: 44.98 }
+    prices: [
+        { puissance: 6, abonnement: 13.72 },
+        { puissance: 9, abonnement: 17.58 },
+        { puissance: 12, abonnement: 21.27 },
+        { puissance: 15, abonnement: 24.20 },
+        { puissance: 18, abonnement: 28.02 },
+        { puissance: 24, abonnement: 35.51 },
+        { puissance: 30, abonnement: 41.99 },
+        { puissance: 36, abonnement: 48.39 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHC: 29.30
+            prixKwhHC: 21.90
         },
         weekend: {
-            prixKwhHC: 21.73
+            prixKwhHC: 16.55
         }
     })),
     hc: [{
@@ -47,28 +47,28 @@ abonnements.push({
 abonnements.push({
     name: "EDF - Zen Week-End Plus HC",
     offer_type: "Marché",
-    lastUpdate: "2024-12-01",
+    lastUpdate: "2025-03-14",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/electricite-gaz/offres-electricite/offres-marche/electricite-weekend/zen-week-end-plus.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-zen-week-end-plus.pdf",
-    prices: [        
-        { puissance: 6, abonnement: 13.21 },
-        { puissance: 9, abonnement: 17.01 },
-        { puissance: 12, abonnement: 20.51 },
-        { puissance: 15, abonnement: 23.86 },
-        { puissance: 18, abonnement: 27.17 },
-        { puissance: 24, abonnement: 34.13 },
-        { puissance: 30, abonnement: 40.47 },
-        { puissance: 36, abonnement: 46.87 }
+    prices: [
+        { puissance: 6, abonnement: 14.04 },
+        { puissance: 9, abonnement: 18.01 },
+        { puissance: 12, abonnement: 21.69 },
+        { puissance: 15, abonnement: 25.16 },
+        { puissance: 18, abonnement: 28.74 },
+        { puissance: 24, abonnement: 36.23 },
+        { puissance: 30, abonnement: 43.00 },
+        { puissance: 36, abonnement: 49.97 }
     ].map(item => ({
         ...item,
         bleu: {
-            prixKwhHP: 30.41,
-            prixKwhHC: 22.50
+            prixKwhHP: 22.69,
+            prixKwhHC: 17.10
         },
         weekend: {
-            prixKwhHP: 22.50,
-            prixKwhHC: 22.50,
+            prixKwhHP: 17.10,
+            prixKwhHC: 17.10,
         }
     })),
     hc: [{


### PR DESCRIPTION
A partir des grilles disponibles sur chacune des offres, applicables à partir du 14 mars 2025
Pas de changement en Zen Fixe / Zen Online