### PR TITLE
ajoute tarifs enercoop base, flexibilite heures creuses saison nuitWE #155

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Un outil pour simuler les différents tarifs de fournisseurs d'électricité dep
 [Version en ligne: https://comparateur-abonnements-electricite.fr](https://comparateur-abonnements-electricite.fr)
 
 ## Derniers tarifs: 
+* Enercoop : 18 avril 2026
 * EDF : 2026-02-01
 * Alpiq : 2025-10-27
 * Alterna : 2025-12-18
@@ -13,7 +14,6 @@ Un outil pour simuler les différents tarifs de fournisseurs d'électricité dep
 * Octopus : 2025-10-27
 * La belle énergie : 2025-12-01
 * ~~Ekwateur : 30 janvier 2024~~
-* ~~Enercoop : 01 Février 2024~~
 * ~~ES : 01 Février 2024~~
 * ~~Ilek : 01 Février 2024~~
 * ~~OHM Energie : 01 Février 2024~~

--- a/index.html
+++ b/index.html
@@ -592,6 +592,9 @@
     <script src="./scripts/tarifs/edf/zenWeekEnd.js"></script>
     <script src="./scripts/tarifs/edf/zenWeekEndPlus.js"></script>
 
+    <script src="./scripts/tarifs/enercoop/base.js"></script>
+    <script src="./scripts/tarifs/enercoop/flexibiliteHC.js"></script>
+    <script src="./scripts/tarifs/enercoop/flexibiliteHCWE.js"></script>
     <script src="./scripts/tarifs/enercoop/flexibiliteSaison.js"></script>  
 
     <script src="./scripts/tarifs/engie/electHappyHeuresVertes1an.js"></script>    

--- a/scripts/tarifs/enercoop/base.js
+++ b/scripts/tarifs/enercoop/base.js
@@ -1,0 +1,63 @@
+abonnements.push(
+    {
+        name: "Enercoop - Base",
+        offer_type: "Marché",
+        lastUpdate: "2026-02-16",
+        isCommunity: true,
+        subscription_url: "https://souscription.enercoop.fr/",
+        price_url: "https://www.faq.enercoop.fr/hc/fr/articles/360024967152-Annexes-tarifaires",
+        prices: [
+            { puissance: 1, abonnement: 6.16, bleu: { prixKwhHC: 25.314} },
+            { puissance: 2, abonnement: 7.85, bleu: { prixKwhHC: 25.314} },
+            { puissance: 3, abonnement: 9.54, bleu: { prixKwhHC: 25.314} },
+            { puissance: 4, abonnement: 11.37, bleu: { prixKwhHC: 25.314} },
+            { puissance: 5, abonnement: 13.09, bleu: { prixKwhHC: 25.314} },
+            { puissance: 6, abonnement: 14.82, bleu: { prixKwhHC: 25.314} },
+            { puissance: 7, abonnement: 16.69, bleu: { prixKwhHC: 25.621} },
+            { puissance: 8, abonnement: 18.44, bleu: { prixKwhHC: 25.621} },
+            { puissance: 9, abonnement: 20.19, bleu: { prixKwhHC: 25.621} },
+            { puissance: 10, abonnement: 21.94, bleu: { prixKwhHC: 25.621} },
+            { puissance: 11, abonnement: 23.68, bleu: { prixKwhHC: 25.621} },
+            { puissance: 12, abonnement: 25.43, bleu: { prixKwhHC: 25.621} },
+            { puissance: 13, abonnement: 27.06, bleu: { prixKwhHC: 25.621} },
+            { puissance: 14, abonnement: 28.8, bleu: { prixKwhHC: 25.621} },
+            { puissance: 15, abonnement: 30.54, bleu: { prixKwhHC: 25.621} },
+            { puissance: 16, abonnement: 32.28, bleu: { prixKwhHC: 25.621} },
+            { puissance: 17, abonnement: 34.02, bleu: { prixKwhHC: 25.621} },
+            { puissance: 18, abonnement: 35.76, bleu: { prixKwhHC: 25.621} },
+            { puissance: 19, abonnement: 37.49, bleu: { prixKwhHC: 25.621} },
+            { puissance: 20, abonnement: 39.23, bleu: { prixKwhHC: 25.621} },
+            { puissance: 21, abonnement: 40.97, bleu: { prixKwhHC: 25.621} },
+            { puissance: 22, abonnement: 42.71, bleu: { prixKwhHC: 25.621} },
+            { puissance: 23, abonnement: 44.45, bleu: { prixKwhHC: 25.621} },
+            { puissance: 24, abonnement: 46.23, bleu: { prixKwhHC: 25.621} },
+            { puissance: 25, abonnement: 47.97, bleu: { prixKwhHC: 25.621} },
+            { puissance: 26, abonnement: 49.72, bleu: { prixKwhHC: 25.621} },
+            { puissance: 27, abonnement: 51.46, bleu: { prixKwhHC: 25.621} },
+            { puissance: 28, abonnement: 53.2, bleu: { prixKwhHC: 25.621} },
+            { puissance: 29, abonnement: 54.94, bleu: { prixKwhHC: 25.621} },
+            { puissance: 30, abonnement: 56.68, bleu: { prixKwhHC: 25.621} },
+            { puissance: 31, abonnement: 58.42, bleu: { prixKwhHC: 25.621} },
+            { puissance: 32, abonnement: 60.16, bleu: { prixKwhHC: 25.621} },
+            { puissance: 33, abonnement: 61.9, bleu: { prixKwhHC: 25.621} },
+            { puissance: 34, abonnement: 63.64, bleu: { prixKwhHC: 25.621} },
+            { puissance: 35, abonnement: 65.38, bleu: { prixKwhHC: 25.621} },
+            { puissance: 36, abonnement: 67.12, bleu: { prixKwhHC: 25.621} }
+        ],
+        hc: [{
+            start: { hour: 0, minute: 0 },
+            end: { hour: 24, minute: 0 }
+        }],
+        hasHCCustom: false,
+        hasSpecialDaysCustom: false,
+        specialDays: [],
+        getDayType: function (day) {
+            let dayType = "bleu";
+            return dayType;
+        }
+    }
+);
+
+
+
+

--- a/scripts/tarifs/enercoop/flexibiliteHC.js
+++ b/scripts/tarifs/enercoop/flexibiliteHC.js
@@ -1,0 +1,58 @@
+abonnements.push(
+    {
+        name: "Enercoop - Flexibilité - heures creuses",
+        offer_type: "Marché",
+        lastUpdate: "2026-02-16",
+        isCommunity: true,
+        subscription_url: "https://souscription.enercoop.fr/",
+        price_url: "https://www.faq.enercoop.fr/hc/fr/articles/360024967152-Annexes-tarifaires",
+        prices: [
+            { puissance: 1, abonnement: 6.6 },
+            { puissance: 2, abonnement: 8.75 },
+            { puissance: 3, abonnement: 10.89 },
+            { puissance: 4, abonnement: 13.4 },
+            { puissance: 5, abonnement: 15.64 },
+            { puissance: 6, abonnement: 17.87 },
+            { puissance: 7, abonnement: 19.68 },
+            { puissance: 8, abonnement: 21.86 },
+            { puissance: 9, abonnement: 24.03 },
+            { puissance: 10, abonnement: 26.21 },
+            { puissance: 11, abonnement: 28.38 },
+            { puissance: 12, abonnement: 30.56 },
+            { puissance: 13, abonnement: 30.87 },
+            { puissance: 14, abonnement: 32.9 },
+            { puissance: 15, abonnement: 34.94 },
+            { puissance: 16, abonnement: 36.97 },
+            { puissance: 17, abonnement: 39 },
+            { puissance: 18, abonnement: 41.03 },
+            { puissance: 19, abonnement: 43.06 },
+            { puissance: 20, abonnement: 45.09 },
+            { puissance: 21, abonnement: 47.13 },
+            { puissance: 22, abonnement: 49.16 },
+            { puissance: 23, abonnement: 51.19 },
+            { puissance: 24, abonnement: 52.09 },
+            { puissance: 25, abonnement: 54.08 },
+            { puissance: 26, abonnement: 56.06 },
+            { puissance: 27, abonnement: 58.05 },
+            { puissance: 28, abonnement: 60.03 },
+            { puissance: 29, abonnement: 62.02 },
+            { puissance: 30, abonnement: 64 },
+            { puissance: 31, abonnement: 65.98 },
+            { puissance: 32, abonnement: 67.97 },
+            { puissance: 33, abonnement: 69.95 },
+            { puissance: 34, abonnement: 71.94 },
+            { puissance: 35, abonnement: 73.92 },
+            { puissance: 36, abonnement: 75.91 }
+        ].map(item => ({
+            ...item,
+            bleu: { prixKwhHP: 27.456, prixKwhHC: 18.95 }
+        })),
+        hc: [],
+        hasHCCustom: true,
+        hasSpecialDaysCustom: false,
+        specialDays: [],
+        getDayType: function (day) {
+            let dayType = "bleu";
+            return dayType;
+        }
+    });

--- a/scripts/tarifs/enercoop/flexibiliteHCWE.js
+++ b/scripts/tarifs/enercoop/flexibiliteHCWE.js
@@ -1,0 +1,78 @@
+abonnements.push(
+{
+        name: "Enercoop - Flexibilité - nuit & week-end",
+        offer_type: "Marché",
+        lastUpdate: "2026-02-16",
+        isCommunity: true,
+        subscription_url: "https://souscription.enercoop.fr/",
+        price_url: "https://www.faq.enercoop.fr/hc/fr/articles/360024967152-Annexes-tarifaires",
+		prices: [
+		        { puissance: 1, abonnement: 6.19 },
+		        { puissance: 2, abonnement: 7.92 },
+		        { puissance: 3, abonnement: 9.65 },
+		        { puissance: 4, abonnement: 11.64 },
+		        { puissance: 5, abonnement: 13.43 },
+		        { puissance: 6, abonnement: 15.23 },
+		        { puissance: 7, abonnement: 17.03 },
+		        { puissance: 8, abonnement: 18.83 },
+		        { puissance: 9, abonnement: 20.63 },
+		        { puissance: 10, abonnement: 22.42 },
+		        { puissance: 11, abonnement: 24.22 },
+		        { puissance: 12, abonnement: 26.02 },
+		        { puissance: 13, abonnement: 27.75 },
+		        { puissance: 14, abonnement: 29.54 },
+		        { puissance: 15, abonnement: 31.33 },
+		        { puissance: 16, abonnement: 33.12 },
+		        { puissance: 17, abonnement: 34.91 },
+		        { puissance: 18, abonnement: 36.7 },
+		        { puissance: 19, abonnement: 38.49 },
+		        { puissance: 20, abonnement: 40.28 },
+		        { puissance: 21, abonnement: 42.08 },
+		        { puissance: 22, abonnement: 43.87 },
+		        { puissance: 23, abonnement: 45.66 },
+		        { puissance: 24, abonnement: 48.24 },
+		        { puissance: 25, abonnement: 50.06 },
+		        { puissance: 26, abonnement: 51.89 },
+		        { puissance: 27, abonnement: 53.71 },
+		        { puissance: 28, abonnement: 55.54 },
+		        { puissance: 29, abonnement: 57.36 },
+		        { puissance: 30, abonnement: 59.19 },
+		        { puissance: 31, abonnement: 61.01 },
+		        { puissance: 32, abonnement: 62.83 },
+		        { puissance: 33, abonnement: 64.66 },
+		        { puissance: 34, abonnement: 66.48 },
+		        { puissance: 35, abonnement: 68.31 },
+		        { puissance: 36, abonnement: 70.13 }
+		].map(item => ({
+		    ...item,
+		    bleu: {
+		        prixKwhHP: 29.286, prixKwhHC: 16.357
+		    },
+		    weekend: {
+		        prixKwhHP: 16.357, prixKwhHC: 16.357
+		    }
+		})),
+		hc: [{
+		    start: { hour: 23, minute: 0 },
+		    end: { hour: 24, minute: 0 }
+		},
+		{
+		    start: { hour: 0, minute: 0 },
+		    end: { hour: 5, minute: 59 }
+		}],
+		hasHCCustom: true,
+		hasSpecialDaysCustom: false,
+		specialDays: [0, 6],
+		getDayType: function (day) {
+		    let dayType = "bleu";
+
+		    const isoDate = new Date(day.date);
+		    const dayOfWeek = isoDate.getDay();
+
+		    if (this.specialDays.includes(dayOfWeek)) {
+		        dayType = "weekend";
+		    }
+
+		    return dayType;
+		}
+	});


### PR DESCRIPTION
…e nuit & week-end

Pour couvrir l'ensemble des offres Enercoop, il manquera encore l'option Jours de pointe, mais je ne suis pas sûr de savoir l'intégrer, et de ce que je comprends elle a peu d'intérêt si pas d'historique des jours concernés et si les consommations n'ont pas été adaptées sur ces jours dans l'historique... #155 