### PR TITLE
Mise à jour tarifs EDF Tempo (grille du 1er août 2026)

### DIFF
--- a/import/manifest.json
+++ b/import/manifest.json
@@ -42,11 +42,11 @@
     "lastApplied": "2026-07-18"
   },
   "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_Tarif_Bleu.pdf": {
-    "lastChecked": "2026-07-18",
-    "etag": "\"2b8dc-6563f70595c84\"",
-    "lastModified": "Fri, 10 Jul 2026 10:45:28 GMT",
-    "sha256": "4e728fe98ce658c15b3c2a3ec7ce8dc9ab70493752f88d5d6e02d3f99dac36e2",
-    "lastApplied": "2026-07-18"
+    "lastChecked": "2026-08-16",
+    "etag": "\"461ff-65903ef4c62d6\"",
+    "lastModified": "Fri, 14 Aug 2026 16:01:34 GMT",
+    "sha256": "0f713ec7d61f8bf934e9ba9209dc4141a994d46abab3c34a0936529e3a6e9c31",
+    "lastApplied": "2026-08-16"
   },
   "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/grille-prix-vert-electrique-auto.pdf": {
     "lastChecked": "2026-07-18",

--- a/scripts/tarifs/edf/tempo.js
+++ b/scripts/tarifs/edf/tempo.js
@@ -3,15 +3,15 @@
 defineTarif({
     name: "EDF - Tempo",
     offer_type: "TRV",
-    lastUpdate: "2026-02-01",
+    lastUpdate: "2026-08-01",
     isCommunity: false,
     subscription_url: "https://particulier.edf.fr/fr/accueil/gestion-contrat/options/tempo/details.html",
     price_url: "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_Tarif_Bleu.pdf",
-    subscriptions: { 6: 15.59, 9: 19.38, 12: 23.07, 15: 26.47, 18: 30.04, 30: 44.73, 36: 52.42 },
+    subscriptions: { 6: 15.8, 9: 19.7, 12: 23.5, 15: 27.01, 18: 30.69, 30: 45.82, 36: 53.76 },
     dayTypes: {
-        bleu: { HP: 16.12, HC: 13.25 },
-        blanc: { HP: 18.71, HC: 14.99 },
-        rouge: { HP: 70.60, HC: 15.75 }
+        bleu: { HP: 16.54, HC: 13.56 },
+        blanc: { HP: 19.21, HC: 15.36 },
+        rouge: { HP: 72.95, HC: 16.15 }
     },
     dayRule: {
         type: "calendar",

--- a/tests/golden/contracts-edf.json
+++ b/tests/golden/contracts-edf.json
@@ -168,121 +168,121 @@
   {
     "name": "EDF - Tempo",
     "offer_type": "TRV",
-    "lastUpdate": "2026-02-01",
+    "lastUpdate": "2026-08-01",
     "isCommunity": false,
     "subscription_url": "https://particulier.edf.fr/fr/accueil/gestion-contrat/options/tempo/details.html",
     "price_url": "https://particulier.edf.fr/content/dam/2-Actifs/Documents/Offres/Grille_prix_Tarif_Bleu.pdf",
     "prices": [
       {
         "puissance": 6,
-        "abonnement": 15.59,
+        "abonnement": 15.8,
         "bleu": {
-          "prixKwhHP": 16.12,
-          "prixKwhHC": 13.25
+          "prixKwhHP": 16.54,
+          "prixKwhHC": 13.56
         },
         "blanc": {
-          "prixKwhHP": 18.71,
-          "prixKwhHC": 14.99
+          "prixKwhHP": 19.21,
+          "prixKwhHC": 15.36
         },
         "rouge": {
-          "prixKwhHP": 70.6,
-          "prixKwhHC": 15.75
+          "prixKwhHP": 72.95,
+          "prixKwhHC": 16.15
         }
       },
       {
         "puissance": 9,
-        "abonnement": 19.38,
+        "abonnement": 19.7,
         "bleu": {
-          "prixKwhHP": 16.12,
-          "prixKwhHC": 13.25
+          "prixKwhHP": 16.54,
+          "prixKwhHC": 13.56
         },
         "blanc": {
-          "prixKwhHP": 18.71,
-          "prixKwhHC": 14.99
+          "prixKwhHP": 19.21,
+          "prixKwhHC": 15.36
         },
         "rouge": {
-          "prixKwhHP": 70.6,
-          "prixKwhHC": 15.75
+          "prixKwhHP": 72.95,
+          "prixKwhHC": 16.15
         }
       },
       {
         "puissance": 12,
-        "abonnement": 23.07,
+        "abonnement": 23.5,
         "bleu": {
-          "prixKwhHP": 16.12,
-          "prixKwhHC": 13.25
+          "prixKwhHP": 16.54,
+          "prixKwhHC": 13.56
         },
         "blanc": {
-          "prixKwhHP": 18.71,
-          "prixKwhHC": 14.99
+          "prixKwhHP": 19.21,
+          "prixKwhHC": 15.36
         },
         "rouge": {
-          "prixKwhHP": 70.6,
-          "prixKwhHC": 15.75
+          "prixKwhHP": 72.95,
+          "prixKwhHC": 16.15
         }
       },
       {
         "puissance": 15,
-        "abonnement": 26.47,
+        "abonnement": 27.01,
         "bleu": {
-          "prixKwhHP": 16.12,
-          "prixKwhHC": 13.25
+          "prixKwhHP": 16.54,
+          "prixKwhHC": 13.56
         },
         "blanc": {
-          "prixKwhHP": 18.71,
-          "prixKwhHC": 14.99
+          "prixKwhHP": 19.21,
+          "prixKwhHC": 15.36
         },
         "rouge": {
-          "prixKwhHP": 70.6,
-          "prixKwhHC": 15.75
+          "prixKwhHP": 72.95,
+          "prixKwhHC": 16.15
         }
       },
       {
         "puissance": 18,
-        "abonnement": 30.04,
+        "abonnement": 30.69,
         "bleu": {
-          "prixKwhHP": 16.12,
-          "prixKwhHC": 13.25
+          "prixKwhHP": 16.54,
+          "prixKwhHC": 13.56
         },
         "blanc": {
-          "prixKwhHP": 18.71,
-          "prixKwhHC": 14.99
+          "prixKwhHP": 19.21,
+          "prixKwhHC": 15.36
         },
         "rouge": {
-          "prixKwhHP": 70.6,
-          "prixKwhHC": 15.75
+          "prixKwhHP": 72.95,
+          "prixKwhHC": 16.15
         }
       },
       {
         "puissance": 30,
-        "abonnement": 44.73,
+        "abonnement": 45.82,
         "bleu": {
-          "prixKwhHP": 16.12,
-          "prixKwhHC": 13.25
+          "prixKwhHP": 16.54,
+          "prixKwhHC": 13.56
         },
         "blanc": {
-          "prixKwhHP": 18.71,
-          "prixKwhHC": 14.99
+          "prixKwhHP": 19.21,
+          "prixKwhHC": 15.36
         },
         "rouge": {
-          "prixKwhHP": 70.6,
-          "prixKwhHC": 15.75
+          "prixKwhHP": 72.95,
+          "prixKwhHC": 16.15
         }
       },
       {
         "puissance": 36,
-        "abonnement": 52.42,
+        "abonnement": 53.76,
         "bleu": {
-          "prixKwhHP": 16.12,
-          "prixKwhHC": 13.25
+          "prixKwhHP": 16.54,
+          "prixKwhHC": 13.56
         },
         "blanc": {
-          "prixKwhHP": 18.71,
-          "prixKwhHC": 14.99
+          "prixKwhHP": 19.21,
+          "prixKwhHC": 15.36
         },
         "rouge": {
-          "prixKwhHP": 70.6,
-          "prixKwhHC": 15.75
+          "prixKwhHP": 72.95,
+          "prixKwhHC": 16.15
         }
       }
     ],

--- a/tests/golden/daily-9kva.json
+++ b/tests/golden/daily-9kva.json
@@ -1123,560 +1123,560 @@
     {
       "date": "2025/01/31",
       "conso": 101169,
-      "price": 53.55450679,
+      "price": 55.28474137,
       "consoHC": 33721,
-      "priceHC": 5.3110575,
+      "priceHC": 5.4459415,
       "consoHP": 67448,
-      "priceHP": 47.618288
+      "priceHP": 49.203316
     },
     {
       "date": "2025/01/30",
       "conso": 51928,
-      "price": 26.95408129,
+      "price": 27.81699062,
       "consoHC": 18654,
-      "priceHC": 2.837476,
+      "priceHC": 2.90812375,
       "consoHP": 33274,
-      "priceHP": 23.491444
+      "priceHP": 24.273383
     },
     {
       "date": "2025/01/29",
       "conso": 51722,
-      "price": 9.42321849,
+      "price": 9.66152907,
       "consoHC": 17818,
-      "priceHC": 2.4546188,
+      "priceHC": 2.5130868,
       "consoHP": 33904,
-      "priceHP": 6.3434384
+      "priceHP": 6.5129584
     },
     {
       "date": "2025/01/28",
       "conso": 52000,
-      "price": 8.48292529,
+      "price": 8.69153987,
       "consoHC": 18280,
-      "priceHC": 2.4221,
+      "priceHC": 2.478768,
       "consoHP": 33720,
-      "priceHP": 5.435664
+      "priceHP": 5.577288
     },
     {
       "date": "2025/01/27",
       "conso": 51344,
-      "price": 8.38676389,
+      "price": 8.59299067,
       "consoHC": 17946,
-      "priceHC": 2.377845,
+      "priceHC": 2.4334776,
       "consoHP": 33398,
-      "priceHP": 5.3837576
+      "priceHP": 5.5240292
     },
     {
       "date": "2025/01/26",
       "conso": 51622,
-      "price": 8.43571029,
+      "price": 8.64326307,
       "consoHC": 17802,
-      "priceHC": 2.358765,
+      "priceHC": 2.4139512,
       "consoHP": 33820,
-      "priceHP": 5.451784
+      "priceHP": 5.593828
     },
     {
       "date": "2025/01/25",
       "conso": 52316,
-      "price": 8.51991629,
+      "price": 8.72932347,
       "consoHC": 18766,
-      "priceHC": 2.486495,
+      "priceHC": 2.5446696,
       "consoHP": 33550,
-      "priceHP": 5.40826
+      "priceHP": 5.54917
     },
     {
       "date": "2025/01/24",
       "conso": 51798,
-      "price": 8.68150499,
+      "price": 8.89727447,
       "consoHC": 17982,
-      "priceHC": 2.6052045,
+      "priceHC": 2.6686242,
       "consoHP": 33816,
-      "priceHP": 5.4511392
+      "priceHP": 5.5931664
     },
     {
       "date": "2025/01/23",
       "conso": 51488,
-      "price": 9.69972849,
+      "price": 9.94838647,
       "consoHC": 17544,
-      "priceHC": 2.7236448,
+      "priceHC": 2.7922602,
       "consoHP": 33944,
-      "priceHP": 6.3509224
+      "priceHP": 6.5206424
     },
     {
       "date": "2025/01/22",
       "conso": 52424,
-      "price": 27.29508629,
+      "price": 28.16971987,
       "consoHC": 18854,
-      "priceHC": 2.969505,
+      "priceHC": 3.044921,
       "consoHP": 33570,
-      "priceHP": 23.70042
+      "priceHP": 24.489315
     },
     {
       "date": "2025/01/21",
       "conso": 51560,
-      "price": 27.20069229,
+      "price": 28.07335187,
       "consoHC": 17914,
-      "priceHC": 2.821455,
+      "priceHC": 2.893111,
       "consoHP": 33646,
-      "priceHP": 23.754076
+      "priceHP": 24.544757
     },
     {
       "date": "2025/01/20",
       "conso": 52254,
-      "price": 27.05394279,
+      "price": 27.92012892,
       "consoHC": 18480,
-      "priceHC": 2.5843375,
+      "priceHC": 2.64651205,
       "consoHP": 33774,
-      "priceHP": 23.844444
+      "priceHP": 24.638133
     },
     {
       "date": "2025/01/19",
       "conso": 51632,
-      "price": 8.65750429,
+      "price": 8.87266507,
       "consoHC": 18042,
-      "priceHC": 2.617635,
+      "priceHC": 2.6813952,
       "consoHP": 33590,
-      "priceHP": 5.414708
+      "priceHP": 5.555786
     },
     {
       "date": "2025/01/18",
       "conso": 51374,
-      "price": 9.66217449,
+      "price": 9.90970792,
       "consoHC": 18054,
-      "priceHC": 2.8028412,
+      "priceHC": 2.87345205,
       "consoHP": 33320,
-      "priceHP": 6.234172
+      "priceHP": 6.400772
     },
     {
       "date": "2025/01/17",
       "conso": 52154,
-      "price": 27.34690329,
+      "price": 28.22381087,
       "consoHC": 18412,
-      "priceHC": 2.89989,
+      "priceHC": 2.973538,
       "consoHP": 33742,
-      "priceHP": 23.821852
+      "priceHP": 24.614789
     },
     {
       "date": "2025/01/16",
       "conso": 51948,
-      "price": 27.38466629,
+      "price": 28.26324587,
       "consoHC": 18078,
-      "priceHC": 2.847285,
+      "priceHC": 2.919597,
       "consoHP": 33870,
-      "priceHP": 23.91222
+      "priceHP": 24.708165
     },
     {
       "date": "2025/01/15",
       "conso": 51326,
-      "price": 27.18577729,
+      "price": 28.05828087,
       "consoHC": 17640,
-      "priceHC": 2.7783,
+      "priceHC": 2.84886,
       "consoHP": 33686,
-      "priceHP": 23.782316
+      "priceHP": 24.573937
     },
     {
       "date": "2025/01/14",
       "conso": 52418,
-      "price": 27.45649729,
+      "price": 28.33687887,
       "consoHC": 18552,
-      "priceHC": 2.92194,
+      "priceHC": 2.996148,
       "consoHP": 33866,
-      "priceHP": 23.909396
+      "priceHP": 24.705247
     },
     {
       "date": "2025/01/13",
       "conso": 51398,
-      "price": 26.96641429,
+      "price": 27.83086317,
       "consoHC": 17560,
-      "priceHC": 2.451625,
+      "priceHC": 2.5105583,
       "consoHP": 33838,
-      "priceHP": 23.889628
+      "priceHP": 24.684821
     },
     {
       "date": "2025/01/12",
       "conso": 51642,
-      "price": 8.64494759,
+      "price": 8.85960287,
       "consoHC": 18576,
-      "priceHC": 2.6895471,
+      "priceHC": 2.7550026,
       "consoHP": 33066,
-      "priceHP": 5.3302392
+      "priceHP": 5.4691164
     },
     {
       "date": "2025/01/11",
       "conso": 51920,
-      "price": 9.76434129,
+      "price": 10.01461927,
       "consoHC": 18138,
-      "priceHC": 2.8185678,
+      "priceHC": 2.8896132,
       "consoHP": 33782,
-      "priceHP": 6.3206122
+      "priceHP": 6.4895222
     },
     {
       "date": "2025/01/10",
       "conso": 51662,
-      "price": 27.04621009,
+      "price": 27.91283382,
       "consoHC": 18150,
-      "priceHC": 2.7615768,
+      "priceHC": 2.83034595,
       "consoHP": 33512,
-      "priceHP": 23.659472
+      "priceHP": 24.447004
     },
     {
       "date": "2025/01/09",
       "conso": 52148,
-      "price": 9.68968569,
+      "price": 9.93655267,
       "consoHC": 18612,
-      "priceHC": 2.7899388,
+      "priceHC": 2.8588032,
       "consoHP": 33536,
-      "priceHP": 6.2745856
+      "priceHP": 6.4422656
     },
     {
       "date": "2025/01/08",
       "conso": 52236,
-      "price": 9.72244409,
+      "price": 9.97032047,
       "consoHC": 18174,
-      "priceHC": 2.7242826,
+      "priceHC": 2.7915264,
       "consoHP": 34062,
-      "priceHP": 6.3730002
+      "priceHP": 6.5433102
     },
     {
       "date": "2025/01/07",
       "conso": 51476,
-      "price": 9.37381569,
+      "price": 9.61077947,
       "consoHC": 17840,
-      "priceHC": 2.4553588,
+      "priceHC": 2.51382,
       "consoHP": 33636,
-      "priceHP": 6.2932956
+      "priceHP": 6.4614756
     },
     {
       "date": "2025/01/06",
       "conso": 51806,
-      "price": 8.44109089,
+      "price": 8.64848587,
       "consoHC": 18648,
-      "priceHC": 2.47086,
+      "priceHC": 2.5286688,
       "consoHP": 33158,
-      "priceHP": 5.3450696
+      "priceHP": 5.4843332
     },
     {
       "date": "2025/01/05",
       "conso": 52050,
-      "price": 8.72746349,
+      "price": 8.94449987,
       "consoHC": 17760,
-      "priceHC": 2.5747542,
+      "priceHC": 2.63745,
       "consoHP": 34290,
-      "priceHP": 5.527548
+      "priceHP": 5.671566
     },
     {
       "date": "2025/01/04",
       "conso": 51480,
-      "price": 9.66265789,
+      "price": 9.91006162,
       "consoHC": 18672,
-      "priceHC": 2.8991198,
+      "priceHC": 2.97216095,
       "consoHP": 32808,
-      "priceHP": 6.1383768
+      "priceHP": 6.3024168
     },
     {
       "date": "2025/01/03",
       "conso": 51724,
-      "price": 27.33073729,
+      "price": 28.20775787,
       "consoHC": 17888,
-      "priceHC": 2.81736,
+      "priceHC": 2.888912,
       "consoHP": 33836,
-      "priceHP": 23.888216
+      "priceHP": 24.683362
     },
     {
       "date": "2025/01/02",
       "conso": 51950,
-      "price": 26.97304279,
+      "price": 27.83684142,
       "consoHC": 18246,
-      "priceHC": 2.5528575,
+      "priceHC": 2.61428955,
       "consoHP": 33704,
-      "priceHP": 23.795024
+      "priceHP": 24.587068
     },
     {
       "date": "2025/01/01",
       "conso": 52246,
-      "price": 8.73484789,
+      "price": 8.95176227,
       "consoHC": 18760,
-      "priceHC": 2.7117434,
+      "priceHC": 2.777694,
       "consoHP": 33486,
-      "priceHP": 5.3979432
+      "priceHP": 5.5385844
     },
     {
       "date": "2024/12/31",
       "conso": 52074,
-      "price": 9.78729049,
+      "price": 10.03812922,
       "consoHC": 18270,
-      "priceHC": 2.8374008,
+      "priceHC": 2.90889695,
       "consoHP": 33804,
-      "priceHP": 6.3247284
+      "priceHP": 6.4937484
     },
     {
       "date": "2024/12/30",
       "conso": 51868,
-      "price": 27.08997329,
+      "price": 27.95806227,
       "consoHC": 17936,
-      "priceHC": 2.50882,
+      "priceHC": 2.5691844,
       "consoHP": 33932,
-      "priceHP": 23.955992
+      "priceHP": 24.753394
     },
     {
       "date": "2024/12/29",
       "conso": 51644,
-      "price": 8.64004819,
+      "price": 8.85451327,
       "consoHC": 18744,
-      "priceHC": 2.7114069,
+      "priceHC": 2.7773694,
       "consoHP": 32900,
-      "priceHP": 5.30348
+      "priceHP": 5.44166
     },
     {
       "date": "2024/12/28",
       "conso": 51490,
-      "price": 9.69003509,
+      "price": 9.93836697,
       "consoHC": 17908,
-      "priceHC": 2.7816816,
+      "priceHC": 2.8517809,
       "consoHP": 33582,
-      "priceHP": 6.2831922
+      "priceHP": 6.4511022
     },
     {
       "date": "2024/12/27",
       "conso": 51422,
-      "price": 26.72656729,
+      "price": 27.58220712,
       "consoHC": 18422,
-      "priceHC": 2.803406,
+      "priceHC": 2.87322325,
       "consoHP": 33000,
-      "priceHP": 23.298
+      "priceHP": 24.0735
     },
     {
       "date": "2024/12/26",
       "conso": 51562,
-      "price": 9.37891189,
+      "price": 9.61592407,
       "consoHC": 17984,
-      "priceHC": 2.4713068,
+      "priceHC": 2.5301064,
       "consoHP": 33578,
-      "priceHP": 6.2824438
+      "priceHP": 6.4503338
     },
     {
       "date": "2024/12/25",
       "conso": 51944,
-      "price": 8.69542959,
+      "price": 8.91142967,
       "consoHC": 18446,
-      "priceHC": 2.6703907,
+      "priceHC": 2.7353766,
       "consoHP": 33498,
-      "priceHP": 5.3998776
+      "priceHP": 5.5405692
     },
     {
       "date": "2024/12/24",
       "conso": 52534,
-      "price": 9.75282949,
+      "price": 10.00130927,
       "consoHC": 18856,
-      "priceHC": 2.8265144,
+      "priceHC": 2.8962816,
       "consoHP": 33678,
-      "priceHP": 6.3011538
+      "priceHP": 6.4695438
     },
     {
       "date": "2024/12/23",
       "conso": 51774,
-      "price": 9.42056999,
+      "price": 9.65871027,
       "consoHC": 18020,
-      "priceHC": 2.4800353,
+      "priceHC": 2.539083,
       "consoHP": 33754,
-      "priceHP": 6.3153734
+      "priceHP": 6.4841434
     },
     {
       "date": "2024/12/22",
       "conso": 51706,
-      "price": 8.44265009,
+      "price": 8.65030267,
       "consoHC": 18032,
-      "priceHC": 2.38924,
+      "priceHC": 2.4451392,
       "consoHP": 33674,
-      "priceHP": 5.4282488
+      "priceHP": 5.5696796
     },
     {
       "date": "2024/12/21",
       "conso": 51950,
-      "price": 8.69652359,
+      "price": 8.91253647,
       "consoHC": 18598,
-      "priceHC": 2.6950199,
+      "priceHC": 2.7606318,
       "consoHP": 33352,
-      "priceHP": 5.3763424
+      "priceHP": 5.5164208
     },
     {
       "date": "2024/12/20",
       "conso": 51328,
-      "price": 9.33503029,
+      "price": 9.57086867,
       "consoHC": 18004,
-      "priceHC": 2.4749486,
+      "priceHC": 2.5338444,
       "consoHP": 33324,
-      "priceHP": 6.2349204
+      "priceHP": 6.4015404
     },
     {
       "date": "2024/12/19",
       "conso": 52022,
-      "price": 8.47964109,
+      "price": 8.68808627,
       "consoHC": 18518,
-      "priceHC": 2.453635,
+      "priceHC": 2.5110408,
       "consoHP": 33504,
-      "priceHP": 5.4008448
+      "priceHP": 5.5415616
     },
     {
       "date": "2024/12/18",
       "conso": 51850,
-      "price": 8.69012849,
+      "price": 8.90611387,
       "consoHC": 18080,
-      "priceHC": 2.6212432,
+      "priceHC": 2.685072,
       "consoHP": 33770,
-      "priceHP": 5.443724
+      "priceHP": 5.585558
     },
     {
       "date": "2024/12/17",
       "conso": 51644,
-      "price": 9.71020589,
+      "price": 9.95901512,
       "consoHC": 18196,
-      "priceHC": 2.8269238,
+      "priceHC": 2.89817045,
       "consoHP": 33448,
-      "priceHP": 6.2581208
+      "priceHP": 6.4253608
     },
     {
       "date": "2024/12/16",
       "conso": 52372,
-      "price": 26.87654629,
+      "price": 27.73623617,
       "consoHC": 18952,
-      "priceHC": 2.656865,
+      "priceHC": 2.7208623,
       "consoHP": 33420,
-      "priceHP": 23.59452
+      "priceHP": 24.37989
     },
     {
       "date": "2024/12/15",
       "conso": 52166,
-      "price": 8.73670239,
+      "price": 8.95386047,
       "consoHC": 18116,
-      "priceHC": 2.6226811,
+      "priceHC": 2.6865066,
       "consoHP": 34050,
-      "priceHP": 5.48886
+      "priceHP": 5.63187
     },
     {
       "date": "2024/12/14",
       "conso": 51544,
-      "price": 9.69177969,
+      "price": 9.94008867,
       "consoHC": 18128,
-      "priceHC": 2.8144848,
+      "priceHC": 2.8853912,
       "consoHP": 33416,
-      "priceHP": 6.2521336
+      "priceHP": 6.4192136
     },
     {
       "date": "2024/12/13",
       "conso": 51788,
-      "price": 27.18065529,
+      "price": 28.05223787,
       "consoHC": 18244,
-      "priceHC": 2.87343,
+      "priceHC": 2.946406,
       "consoHP": 33544,
-      "priceHP": 23.682064
+      "priceHP": 24.470348
     },
     {
       "date": "2024/12/12",
       "conso": 51616,
-      "price": 27.13820729,
+      "price": 28.00855587,
       "consoHC": 18100,
-      "priceHC": 2.85075,
+      "priceHC": 2.92315,
       "consoHP": 33516,
-      "priceHP": 23.662296
+      "priceHP": 24.449922
     },
     {
       "date": "2024/12/11",
       "conso": 51860,
-      "price": 27.02854229,
+      "price": 27.89460187,
       "consoHC": 18614,
-      "priceHC": 2.931705,
+      "priceHC": 3.006161,
       "consoHP": 33246,
-      "priceHP": 23.471676
+      "priceHP": 24.252957
     },
     {
       "date": "2024/12/10",
       "conso": 51896,
-      "price": 27.13730849,
+      "price": 28.00678567,
       "consoHC": 18280,
-      "priceHC": 2.7792512,
+      "priceHC": 2.8484298,
       "consoHP": 33616,
-      "priceHP": 23.732896
+      "priceHP": 24.522872
     },
     {
       "date": "2024/12/09",
       "conso": 51932,
-      "price": 9.43258359,
+      "price": 9.67090407,
       "consoHC": 18292,
-      "priceHC": 2.5133783,
+      "priceHC": 2.5731762,
       "consoHP": 33640,
-      "priceHP": 6.294044
+      "priceHP": 6.462244
     },
     {
       "date": "2024/12/08",
       "conso": 52072,
-      "price": 8.48242029,
+      "price": 8.69087307,
       "consoHC": 18702,
-      "priceHC": 2.478015,
+      "priceHC": 2.5359912,
       "consoHP": 33370,
-      "priceHP": 5.379244
+      "priceHP": 5.519398
     },
     {
       "date": "2024/12/07",
       "conso": 52454,
-      "price": 8.55806169,
+      "price": 8.76865787,
       "consoHC": 18212,
-      "priceHC": 2.41309,
+      "priceHC": 2.4695472,
       "consoHP": 34242,
-      "priceHP": 5.5198104
+      "priceHP": 5.6636268
     },
     {
       "date": "2024/12/06",
       "conso": 51798,
-      "price": 8.44898529,
+      "price": 8.65669867,
       "consoHC": 18328,
-      "priceHC": 2.42846,
+      "priceHC": 2.4852768,
       "consoHP": 33470,
-      "priceHP": 5.395364
+      "priceHP": 5.535938
     },
     {
       "date": "2024/12/05",
       "conso": 51626,
-      "price": 8.64616619,
+      "price": 8.86091127,
       "consoHC": 18340,
-      "priceHC": 2.6553017,
+      "priceHC": 2.719923,
       "consoHP": 33286,
-      "priceHP": 5.3657032
+      "priceHP": 5.5055044
     },
     {
       "date": "2024/12/04",
       "conso": 51818,
-      "price": 9.75010709,
+      "price": 10.00002677,
       "consoHC": 17902,
-      "priceHC": 2.7792622,
+      "priceHC": 2.8492793,
       "consoHP": 33916,
-      "priceHP": 6.3456836
+      "priceHP": 6.5152636
     },
     {
       "date": "2024/12/03",
       "conso": 52148,
-      "price": 26.85170179,
+      "price": 27.71086692,
       "consoHC": 18710,
-      "priceHC": 2.6193125,
+      "priceHC": 2.68236205,
       "consoHP": 33438,
-      "priceHP": 23.607228
+      "priceHP": 24.393021
     },
     {
       "date": "2024/12/02",
       "conso": 51942,
-      "price": 8.48373549,
+      "price": 8.69249587,
       "consoHC": 17926,
-      "priceHC": 2.375195,
+      "priceHC": 2.4307656,
       "consoHP": 34016,
-      "priceHP": 5.4833792
+      "priceHP": 5.6262464
     },
     {
       "date": "2024/12/01",
       "conso": 51770,
-      "price": 8.45566469,
+      "price": 8.66368947,
       "consoHC": 17938,
-      "priceHC": 2.376785,
+      "priceHC": 2.4323928,
       "consoHP": 33832,
-      "priceHP": 5.4537184
+      "priceHP": 5.5958128
     }
   ],
   "EDF - EJP": [

--- a/tests/golden/monthly-12.json
+++ b/tests/golden/monthly-12.json
@@ -584,289 +584,289 @@
       "year": 2026,
       "month": "01",
       "conso": 1559396,
-      "price": 384.900546,
+      "price": 395.70216685,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 548544,
-      "priceHC": 79.2461712,
+      "priceHC": 81.17768685,
       "consoHP": 1010852,
-      "priceHP": 282.5843748
+      "priceHP": 291.02448
     },
     {
       "year": 2025,
       "month": "12",
       "conso": 1608788,
-      "price": 315.2409807,
+      "price": 323.50181555,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 564622,
-      "priceHC": 78.5682721,
+      "priceHC": 80.44898315,
       "consoHP": 1044166,
-      "priceHP": 213.6027086
+      "priceHP": 219.5528324
     },
     {
       "year": 2025,
       "month": "11",
       "conso": 1559840,
-      "price": 263.5162608,
+      "price": 270.0450812,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 549592,
-      "priceHC": 74.1018236,
+      "priceHC": 75.8497272,
       "consoHP": 1010248,
-      "priceHP": 166.3444372
+      "priceHP": 170.695354
     },
     {
       "year": 2025,
       "month": "10",
       "conso": 799746,
-      "price": 144.9243493,
+      "price": 148.4425098,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 246157,
-      "priceHC": 32.6158025,
+      "priceHC": 33.3788892,
       "consoHP": 553589,
-      "priceHP": 89.2385468
+      "priceHP": 91.5636206
     },
     {
       "year": 2025,
       "month": "09",
       "conso": 799807,
-      "price": 144.92148275,
+      "price": 148.4394127,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246599.5,
-      "priceHC": 32.67443375,
+      "priceHC": 33.4388922,
       "consoHP": 553207.5,
-      "priceHP": 89.177049
+      "priceHP": 91.5005205
     },
     {
       "year": 2025,
       "month": "08",
       "conso": 827880,
-      "price": 149.1429317,
+      "price": 152.7671198,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 257189,
-      "priceHC": 34.0775425,
+      "priceHC": 34.8748284,
       "consoHP": 570691,
-      "priceHP": 91.9953892
+      "priceHP": 94.3922914
     },
     {
       "year": 2025,
       "month": "07",
       "conso": 828294,
-      "price": 149.2282374,
+      "price": 152.854876,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256542,
-      "priceHC": 33.991815,
+      "priceHC": 34.7870952,
       "consoHP": 571752,
-      "priceHP": 92.1664224
+      "priceHP": 94.5677808
     },
     {
       "year": 2025,
       "month": "06",
       "conso": 801096,
-      "price": 145.0471158,
+      "price": 148.5673108,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249462,
-      "priceHC": 33.053715,
+      "priceHC": 33.8270472,
       "consoHP": 551634,
-      "priceHP": 88.9234008
+      "priceHP": 91.2402636
     },
     {
       "year": 2025,
       "month": "05",
       "conso": 828322,
-      "price": 149.225863,
+      "price": 152.8523552,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256782,
-      "priceHC": 34.023615,
+      "priceHC": 34.8196392,
       "consoHP": 571540,
-      "priceHP": 92.132248
+      "priceHP": 94.532716
     },
     {
       "year": 2025,
       "month": "04",
       "conso": 801142,
-      "price": 145.0502834,
+      "price": 148.5705088,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249610,
-      "priceHC": 33.073325,
+      "priceHC": 33.847116,
       "consoHP": 551532,
-      "priceHP": 88.9069584
+      "priceHP": 91.2233928
     },
     {
       "year": 2025,
       "month": "03",
       "conso": 1603692.5,
-      "price": 270.4728702,
+      "price": 277.1808927,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 560133,
-      "priceHC": 75.7056096,
+      "priceHC": 77.4933318,
       "consoHP": 1043559.5,
-      "priceHP": 171.6972606
+      "priceHP": 176.1875609
     },
     {
       "year": 2025,
       "month": "02",
       "conso": 1454383,
-      "price": 279.63032855,
+      "price": 286.84636195,
       "hasErrors": false,
       "nbDays": 28,
       "consoHC": 513571.5,
-      "priceHC": 73.38621615,
+      "priceHC": 75.16352385,
       "consoHP": 940811.5,
-      "priceHP": 183.1741124
+      "priceHP": 188.1828381
     },
     {
       "year": 2025,
       "month": "01",
       "conso": 1656215,
-      "price": 546.1492991,
+      "price": 562.5288099,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 579563,
-      "priceHC": 85.5379871,
+      "priceHC": 87.6452821,
       "consoHP": 1076652,
-      "priceHP": 437.541312
+      "priceHP": 451.3835278
     },
     {
       "year": 2024,
       "month": "12",
       "conso": 1607614,
-      "price": 427.1250026,
+      "price": 439.3530658,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 566798,
-      "priceHC": 81.7199398,
+      "priceHC": 83.7108222,
       "consoHP": 1040816,
-      "priceHP": 322.3350628
+      "priceHP": 332.1422436
     },
     {
       "year": 2024,
       "month": "11",
       "conso": 1555490,
-      "price": 265.240003,
+      "price": 271.828225,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 546890,
-      "priceHC": 74.353696,
+      "priceHC": 76.114254,
       "consoHP": 1008600,
-      "priceHP": 167.816307
+      "priceHP": 172.213971
     },
     {
       "year": 2024,
       "month": "10",
       "conso": 801811,
-      "price": 145.1927097,
+      "price": 148.7170704,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 248405,
-      "priceHC": 32.9136625,
+      "priceHC": 33.683718,
       "consoHP": 553406,
-      "priceHP": 89.2090472
+      "priceHP": 91.5333524
     },
     {
       "year": 2024,
       "month": "09",
       "conso": 799403,
-      "price": 144.87030615,
+      "price": 148.3870739,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246113.5,
-      "priceHC": 32.61003875,
+      "priceHC": 33.3729906,
       "consoHP": 553289.5,
-      "priceHP": 89.1902674
+      "priceHP": 91.5140833
     },
     {
       "year": 2024,
       "month": "08",
       "conso": 828472,
-      "price": 149.2092029,
+      "price": 152.8347598,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 258205,
-      "priceHC": 34.2121625,
+      "priceHC": 35.012598,
       "consoHP": 570267,
-      "priceHP": 91.9270404
+      "priceHP": 94.3221618
     },
     {
       "year": 2024,
       "month": "07",
       "conso": 825926,
-      "price": 148.9390446,
+      "price": 152.559284,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 253318,
-      "priceHC": 33.564635,
+      "priceHC": 34.3499208,
       "consoHP": 572608,
-      "priceHP": 92.3044096
+      "priceHP": 94.7093632
     },
     {
       "year": 2024,
       "month": "06",
       "conso": 800346,
-      "price": 145.0181706,
+      "price": 148.53874,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246258,
-      "priceHC": 32.629185,
+      "priceHC": 33.3925848,
       "consoHP": 554088,
-      "priceHP": 89.3189856
+      "priceHP": 91.6461552
     },
     {
       "year": 2024,
       "month": "05",
       "conso": 825106,
-      "price": 148.7840728,
+      "price": 152.3999948,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 254112,
-      "priceHC": 33.66984,
+      "priceHC": 34.4575872,
       "consoHP": 570994,
-      "priceHP": 92.0442328
+      "priceHP": 94.4424076
     },
     {
       "year": 2024,
       "month": "04",
       "conso": 800686,
-      "price": 149.4052591,
+      "price": 153.0646594,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246406,
-      "priceHC": 33.6555155,
+      "priceHC": 34.4540886,
       "consoHP": 554280,
-      "priceHP": 92.6797436
+      "priceHP": 95.1105708
     },
     {
       "year": 2024,
       "month": "03",
       "conso": 1654175,
-      "price": 391.4975046,
+      "price": 402.4168095,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 577614,
-      "priceHC": 80.7821691,
+      "priceHC": 82.72342335,
       "consoHP": 1076561,
-      "priceHP": 287.6453355
+      "priceHP": 296.19338615
     },
     {
       "year": 2024,
       "month": "02",
       "conso": 1506524.5,
-      "price": 319.3096414,
+      "price": 327.87248315,
       "hasErrors": false,
       "nbDays": 29,
       "consoHC": 528451,
-      "priceHC": 74.5755868,
+      "priceHC": 76.37296865,
       "consoHP": 978073.5,
-      "priceHP": 221.6640546
+      "priceHP": 227.9995145
     }
   ],
   "EDF - EJP": [

--- a/tests/golden/monthly-15.json
+++ b/tests/golden/monthly-15.json
@@ -584,289 +584,289 @@
       "year": 2026,
       "month": "01",
       "conso": 1559396,
-      "price": 388.300546,
+      "price": 399.21216685,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 548544,
-      "priceHC": 79.2461712,
+      "priceHC": 81.17768685,
       "consoHP": 1010852,
-      "priceHP": 282.5843748
+      "priceHP": 291.02448
     },
     {
       "year": 2025,
       "month": "12",
       "conso": 1608788,
-      "price": 318.6409807,
+      "price": 327.01181555,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 564622,
-      "priceHC": 78.5682721,
+      "priceHC": 80.44898315,
       "consoHP": 1044166,
-      "priceHP": 213.6027086
+      "priceHP": 219.5528324
     },
     {
       "year": 2025,
       "month": "11",
       "conso": 1559840,
-      "price": 266.9162608,
+      "price": 273.5550812,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 549592,
-      "priceHC": 74.1018236,
+      "priceHC": 75.8497272,
       "consoHP": 1010248,
-      "priceHP": 166.3444372
+      "priceHP": 170.695354
     },
     {
       "year": 2025,
       "month": "10",
       "conso": 799746,
-      "price": 148.3243493,
+      "price": 151.9525098,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 246157,
-      "priceHC": 32.6158025,
+      "priceHC": 33.3788892,
       "consoHP": 553589,
-      "priceHP": 89.2385468
+      "priceHP": 91.5636206
     },
     {
       "year": 2025,
       "month": "09",
       "conso": 799807,
-      "price": 148.32148275,
+      "price": 151.9494127,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246599.5,
-      "priceHC": 32.67443375,
+      "priceHC": 33.4388922,
       "consoHP": 553207.5,
-      "priceHP": 89.177049
+      "priceHP": 91.5005205
     },
     {
       "year": 2025,
       "month": "08",
       "conso": 827880,
-      "price": 152.5429317,
+      "price": 156.2771198,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 257189,
-      "priceHC": 34.0775425,
+      "priceHC": 34.8748284,
       "consoHP": 570691,
-      "priceHP": 91.9953892
+      "priceHP": 94.3922914
     },
     {
       "year": 2025,
       "month": "07",
       "conso": 828294,
-      "price": 152.6282374,
+      "price": 156.364876,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256542,
-      "priceHC": 33.991815,
+      "priceHC": 34.7870952,
       "consoHP": 571752,
-      "priceHP": 92.1664224
+      "priceHP": 94.5677808
     },
     {
       "year": 2025,
       "month": "06",
       "conso": 801096,
-      "price": 148.4471158,
+      "price": 152.0773108,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249462,
-      "priceHC": 33.053715,
+      "priceHC": 33.8270472,
       "consoHP": 551634,
-      "priceHP": 88.9234008
+      "priceHP": 91.2402636
     },
     {
       "year": 2025,
       "month": "05",
       "conso": 828322,
-      "price": 152.625863,
+      "price": 156.3623552,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256782,
-      "priceHC": 34.023615,
+      "priceHC": 34.8196392,
       "consoHP": 571540,
-      "priceHP": 92.132248
+      "priceHP": 94.532716
     },
     {
       "year": 2025,
       "month": "04",
       "conso": 801142,
-      "price": 148.4502834,
+      "price": 152.0805088,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249610,
-      "priceHC": 33.073325,
+      "priceHC": 33.847116,
       "consoHP": 551532,
-      "priceHP": 88.9069584
+      "priceHP": 91.2233928
     },
     {
       "year": 2025,
       "month": "03",
       "conso": 1603692.5,
-      "price": 273.8728702,
+      "price": 280.6908927,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 560133,
-      "priceHC": 75.7056096,
+      "priceHC": 77.4933318,
       "consoHP": 1043559.5,
-      "priceHP": 171.6972606
+      "priceHP": 176.1875609
     },
     {
       "year": 2025,
       "month": "02",
       "conso": 1454383,
-      "price": 283.03032855,
+      "price": 290.35636195,
       "hasErrors": false,
       "nbDays": 28,
       "consoHC": 513571.5,
-      "priceHC": 73.38621615,
+      "priceHC": 75.16352385,
       "consoHP": 940811.5,
-      "priceHP": 183.1741124
+      "priceHP": 188.1828381
     },
     {
       "year": 2025,
       "month": "01",
       "conso": 1656215,
-      "price": 549.5492991,
+      "price": 566.0388099,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 579563,
-      "priceHC": 85.5379871,
+      "priceHC": 87.6452821,
       "consoHP": 1076652,
-      "priceHP": 437.541312
+      "priceHP": 451.3835278
     },
     {
       "year": 2024,
       "month": "12",
       "conso": 1607614,
-      "price": 430.5250026,
+      "price": 442.8630658,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 566798,
-      "priceHC": 81.7199398,
+      "priceHC": 83.7108222,
       "consoHP": 1040816,
-      "priceHP": 322.3350628
+      "priceHP": 332.1422436
     },
     {
       "year": 2024,
       "month": "11",
       "conso": 1555490,
-      "price": 268.640003,
+      "price": 275.338225,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 546890,
-      "priceHC": 74.353696,
+      "priceHC": 76.114254,
       "consoHP": 1008600,
-      "priceHP": 167.816307
+      "priceHP": 172.213971
     },
     {
       "year": 2024,
       "month": "10",
       "conso": 801811,
-      "price": 148.5927097,
+      "price": 152.2270704,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 248405,
-      "priceHC": 32.9136625,
+      "priceHC": 33.683718,
       "consoHP": 553406,
-      "priceHP": 89.2090472
+      "priceHP": 91.5333524
     },
     {
       "year": 2024,
       "month": "09",
       "conso": 799403,
-      "price": 148.27030615,
+      "price": 151.8970739,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246113.5,
-      "priceHC": 32.61003875,
+      "priceHC": 33.3729906,
       "consoHP": 553289.5,
-      "priceHP": 89.1902674
+      "priceHP": 91.5140833
     },
     {
       "year": 2024,
       "month": "08",
       "conso": 828472,
-      "price": 152.6092029,
+      "price": 156.3447598,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 258205,
-      "priceHC": 34.2121625,
+      "priceHC": 35.012598,
       "consoHP": 570267,
-      "priceHP": 91.9270404
+      "priceHP": 94.3221618
     },
     {
       "year": 2024,
       "month": "07",
       "conso": 825926,
-      "price": 152.3390446,
+      "price": 156.069284,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 253318,
-      "priceHC": 33.564635,
+      "priceHC": 34.3499208,
       "consoHP": 572608,
-      "priceHP": 92.3044096
+      "priceHP": 94.7093632
     },
     {
       "year": 2024,
       "month": "06",
       "conso": 800346,
-      "price": 148.4181706,
+      "price": 152.04874,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246258,
-      "priceHC": 32.629185,
+      "priceHC": 33.3925848,
       "consoHP": 554088,
-      "priceHP": 89.3189856
+      "priceHP": 91.6461552
     },
     {
       "year": 2024,
       "month": "05",
       "conso": 825106,
-      "price": 152.1840728,
+      "price": 155.9099948,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 254112,
-      "priceHC": 33.66984,
+      "priceHC": 34.4575872,
       "consoHP": 570994,
-      "priceHP": 92.0442328
+      "priceHP": 94.4424076
     },
     {
       "year": 2024,
       "month": "04",
       "conso": 800686,
-      "price": 152.8052591,
+      "price": 156.5746594,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246406,
-      "priceHC": 33.6555155,
+      "priceHC": 34.4540886,
       "consoHP": 554280,
-      "priceHP": 92.6797436
+      "priceHP": 95.1105708
     },
     {
       "year": 2024,
       "month": "03",
       "conso": 1654175,
-      "price": 394.8975046,
+      "price": 405.9268095,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 577614,
-      "priceHC": 80.7821691,
+      "priceHC": 82.72342335,
       "consoHP": 1076561,
-      "priceHP": 287.6453355
+      "priceHP": 296.19338615
     },
     {
       "year": 2024,
       "month": "02",
       "conso": 1506524.5,
-      "price": 322.7096414,
+      "price": 331.38248315,
       "hasErrors": false,
       "nbDays": 29,
       "consoHC": 528451,
-      "priceHC": 74.5755868,
+      "priceHC": 76.37296865,
       "consoHP": 978073.5,
-      "priceHP": 221.6640546
+      "priceHP": 227.9995145
     }
   ],
   "EDF - EJP": [

--- a/tests/golden/monthly-18.json
+++ b/tests/golden/monthly-18.json
@@ -584,289 +584,289 @@
       "year": 2026,
       "month": "01",
       "conso": 1559396,
-      "price": 391.870546,
+      "price": 402.89216685,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 548544,
-      "priceHC": 79.2461712,
+      "priceHC": 81.17768685,
       "consoHP": 1010852,
-      "priceHP": 282.5843748
+      "priceHP": 291.02448
     },
     {
       "year": 2025,
       "month": "12",
       "conso": 1608788,
-      "price": 322.2109807,
+      "price": 330.69181555,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 564622,
-      "priceHC": 78.5682721,
+      "priceHC": 80.44898315,
       "consoHP": 1044166,
-      "priceHP": 213.6027086
+      "priceHP": 219.5528324
     },
     {
       "year": 2025,
       "month": "11",
       "conso": 1559840,
-      "price": 270.4862608,
+      "price": 277.2350812,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 549592,
-      "priceHC": 74.1018236,
+      "priceHC": 75.8497272,
       "consoHP": 1010248,
-      "priceHP": 166.3444372
+      "priceHP": 170.695354
     },
     {
       "year": 2025,
       "month": "10",
       "conso": 799746,
-      "price": 151.8943493,
+      "price": 155.6325098,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 246157,
-      "priceHC": 32.6158025,
+      "priceHC": 33.3788892,
       "consoHP": 553589,
-      "priceHP": 89.2385468
+      "priceHP": 91.5636206
     },
     {
       "year": 2025,
       "month": "09",
       "conso": 799807,
-      "price": 151.89148275,
+      "price": 155.6294127,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246599.5,
-      "priceHC": 32.67443375,
+      "priceHC": 33.4388922,
       "consoHP": 553207.5,
-      "priceHP": 89.177049
+      "priceHP": 91.5005205
     },
     {
       "year": 2025,
       "month": "08",
       "conso": 827880,
-      "price": 156.1129317,
+      "price": 159.9571198,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 257189,
-      "priceHC": 34.0775425,
+      "priceHC": 34.8748284,
       "consoHP": 570691,
-      "priceHP": 91.9953892
+      "priceHP": 94.3922914
     },
     {
       "year": 2025,
       "month": "07",
       "conso": 828294,
-      "price": 156.1982374,
+      "price": 160.044876,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256542,
-      "priceHC": 33.991815,
+      "priceHC": 34.7870952,
       "consoHP": 571752,
-      "priceHP": 92.1664224
+      "priceHP": 94.5677808
     },
     {
       "year": 2025,
       "month": "06",
       "conso": 801096,
-      "price": 152.0171158,
+      "price": 155.7573108,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249462,
-      "priceHC": 33.053715,
+      "priceHC": 33.8270472,
       "consoHP": 551634,
-      "priceHP": 88.9234008
+      "priceHP": 91.2402636
     },
     {
       "year": 2025,
       "month": "05",
       "conso": 828322,
-      "price": 156.195863,
+      "price": 160.0423552,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256782,
-      "priceHC": 34.023615,
+      "priceHC": 34.8196392,
       "consoHP": 571540,
-      "priceHP": 92.132248
+      "priceHP": 94.532716
     },
     {
       "year": 2025,
       "month": "04",
       "conso": 801142,
-      "price": 152.0202834,
+      "price": 155.7605088,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249610,
-      "priceHC": 33.073325,
+      "priceHC": 33.847116,
       "consoHP": 551532,
-      "priceHP": 88.9069584
+      "priceHP": 91.2233928
     },
     {
       "year": 2025,
       "month": "03",
       "conso": 1603692.5,
-      "price": 277.4428702,
+      "price": 284.3708927,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 560133,
-      "priceHC": 75.7056096,
+      "priceHC": 77.4933318,
       "consoHP": 1043559.5,
-      "priceHP": 171.6972606
+      "priceHP": 176.1875609
     },
     {
       "year": 2025,
       "month": "02",
       "conso": 1454383,
-      "price": 286.60032855,
+      "price": 294.03636195,
       "hasErrors": false,
       "nbDays": 28,
       "consoHC": 513571.5,
-      "priceHC": 73.38621615,
+      "priceHC": 75.16352385,
       "consoHP": 940811.5,
-      "priceHP": 183.1741124
+      "priceHP": 188.1828381
     },
     {
       "year": 2025,
       "month": "01",
       "conso": 1656215,
-      "price": 553.1192991,
+      "price": 569.7188099,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 579563,
-      "priceHC": 85.5379871,
+      "priceHC": 87.6452821,
       "consoHP": 1076652,
-      "priceHP": 437.541312
+      "priceHP": 451.3835278
     },
     {
       "year": 2024,
       "month": "12",
       "conso": 1607614,
-      "price": 434.0950026,
+      "price": 446.5430658,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 566798,
-      "priceHC": 81.7199398,
+      "priceHC": 83.7108222,
       "consoHP": 1040816,
-      "priceHP": 322.3350628
+      "priceHP": 332.1422436
     },
     {
       "year": 2024,
       "month": "11",
       "conso": 1555490,
-      "price": 272.210003,
+      "price": 279.018225,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 546890,
-      "priceHC": 74.353696,
+      "priceHC": 76.114254,
       "consoHP": 1008600,
-      "priceHP": 167.816307
+      "priceHP": 172.213971
     },
     {
       "year": 2024,
       "month": "10",
       "conso": 801811,
-      "price": 152.1627097,
+      "price": 155.9070704,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 248405,
-      "priceHC": 32.9136625,
+      "priceHC": 33.683718,
       "consoHP": 553406,
-      "priceHP": 89.2090472
+      "priceHP": 91.5333524
     },
     {
       "year": 2024,
       "month": "09",
       "conso": 799403,
-      "price": 151.84030615,
+      "price": 155.5770739,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246113.5,
-      "priceHC": 32.61003875,
+      "priceHC": 33.3729906,
       "consoHP": 553289.5,
-      "priceHP": 89.1902674
+      "priceHP": 91.5140833
     },
     {
       "year": 2024,
       "month": "08",
       "conso": 828472,
-      "price": 156.1792029,
+      "price": 160.0247598,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 258205,
-      "priceHC": 34.2121625,
+      "priceHC": 35.012598,
       "consoHP": 570267,
-      "priceHP": 91.9270404
+      "priceHP": 94.3221618
     },
     {
       "year": 2024,
       "month": "07",
       "conso": 825926,
-      "price": 155.9090446,
+      "price": 159.749284,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 253318,
-      "priceHC": 33.564635,
+      "priceHC": 34.3499208,
       "consoHP": 572608,
-      "priceHP": 92.3044096
+      "priceHP": 94.7093632
     },
     {
       "year": 2024,
       "month": "06",
       "conso": 800346,
-      "price": 151.9881706,
+      "price": 155.72874,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246258,
-      "priceHC": 32.629185,
+      "priceHC": 33.3925848,
       "consoHP": 554088,
-      "priceHP": 89.3189856
+      "priceHP": 91.6461552
     },
     {
       "year": 2024,
       "month": "05",
       "conso": 825106,
-      "price": 155.7540728,
+      "price": 159.5899948,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 254112,
-      "priceHC": 33.66984,
+      "priceHC": 34.4575872,
       "consoHP": 570994,
-      "priceHP": 92.0442328
+      "priceHP": 94.4424076
     },
     {
       "year": 2024,
       "month": "04",
       "conso": 800686,
-      "price": 156.3752591,
+      "price": 160.2546594,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246406,
-      "priceHC": 33.6555155,
+      "priceHC": 34.4540886,
       "consoHP": 554280,
-      "priceHP": 92.6797436
+      "priceHP": 95.1105708
     },
     {
       "year": 2024,
       "month": "03",
       "conso": 1654175,
-      "price": 398.4675046,
+      "price": 409.6068095,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 577614,
-      "priceHC": 80.7821691,
+      "priceHC": 82.72342335,
       "consoHP": 1076561,
-      "priceHP": 287.6453355
+      "priceHP": 296.19338615
     },
     {
       "year": 2024,
       "month": "02",
       "conso": 1506524.5,
-      "price": 326.2796414,
+      "price": 335.06248315,
       "hasErrors": false,
       "nbDays": 29,
       "consoHC": 528451,
-      "priceHC": 74.5755868,
+      "priceHC": 76.37296865,
       "consoHP": 978073.5,
-      "priceHP": 221.6640546
+      "priceHP": 227.9995145
     }
   ],
   "EDF - EJP": [

--- a/tests/golden/monthly-30.json
+++ b/tests/golden/monthly-30.json
@@ -584,289 +584,289 @@
       "year": 2026,
       "month": "01",
       "conso": 1559396,
-      "price": 406.560546,
+      "price": 418.02216685,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 548544,
-      "priceHC": 79.2461712,
+      "priceHC": 81.17768685,
       "consoHP": 1010852,
-      "priceHP": 282.5843748
+      "priceHP": 291.02448
     },
     {
       "year": 2025,
       "month": "12",
       "conso": 1608788,
-      "price": 336.9009807,
+      "price": 345.82181555,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 564622,
-      "priceHC": 78.5682721,
+      "priceHC": 80.44898315,
       "consoHP": 1044166,
-      "priceHP": 213.6027086
+      "priceHP": 219.5528324
     },
     {
       "year": 2025,
       "month": "11",
       "conso": 1559840,
-      "price": 285.1762608,
+      "price": 292.3650812,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 549592,
-      "priceHC": 74.1018236,
+      "priceHC": 75.8497272,
       "consoHP": 1010248,
-      "priceHP": 166.3444372
+      "priceHP": 170.695354
     },
     {
       "year": 2025,
       "month": "10",
       "conso": 799746,
-      "price": 166.5843493,
+      "price": 170.7625098,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 246157,
-      "priceHC": 32.6158025,
+      "priceHC": 33.3788892,
       "consoHP": 553589,
-      "priceHP": 89.2385468
+      "priceHP": 91.5636206
     },
     {
       "year": 2025,
       "month": "09",
       "conso": 799807,
-      "price": 166.58148275,
+      "price": 170.7594127,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246599.5,
-      "priceHC": 32.67443375,
+      "priceHC": 33.4388922,
       "consoHP": 553207.5,
-      "priceHP": 89.177049
+      "priceHP": 91.5005205
     },
     {
       "year": 2025,
       "month": "08",
       "conso": 827880,
-      "price": 170.8029317,
+      "price": 175.0871198,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 257189,
-      "priceHC": 34.0775425,
+      "priceHC": 34.8748284,
       "consoHP": 570691,
-      "priceHP": 91.9953892
+      "priceHP": 94.3922914
     },
     {
       "year": 2025,
       "month": "07",
       "conso": 828294,
-      "price": 170.8882374,
+      "price": 175.174876,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256542,
-      "priceHC": 33.991815,
+      "priceHC": 34.7870952,
       "consoHP": 571752,
-      "priceHP": 92.1664224
+      "priceHP": 94.5677808
     },
     {
       "year": 2025,
       "month": "06",
       "conso": 801096,
-      "price": 166.7071158,
+      "price": 170.8873108,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249462,
-      "priceHC": 33.053715,
+      "priceHC": 33.8270472,
       "consoHP": 551634,
-      "priceHP": 88.9234008
+      "priceHP": 91.2402636
     },
     {
       "year": 2025,
       "month": "05",
       "conso": 828322,
-      "price": 170.885863,
+      "price": 175.1723552,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256782,
-      "priceHC": 34.023615,
+      "priceHC": 34.8196392,
       "consoHP": 571540,
-      "priceHP": 92.132248
+      "priceHP": 94.532716
     },
     {
       "year": 2025,
       "month": "04",
       "conso": 801142,
-      "price": 166.7102834,
+      "price": 170.8905088,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249610,
-      "priceHC": 33.073325,
+      "priceHC": 33.847116,
       "consoHP": 551532,
-      "priceHP": 88.9069584
+      "priceHP": 91.2233928
     },
     {
       "year": 2025,
       "month": "03",
       "conso": 1603692.5,
-      "price": 292.1328702,
+      "price": 299.5008927,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 560133,
-      "priceHC": 75.7056096,
+      "priceHC": 77.4933318,
       "consoHP": 1043559.5,
-      "priceHP": 171.6972606
+      "priceHP": 176.1875609
     },
     {
       "year": 2025,
       "month": "02",
       "conso": 1454383,
-      "price": 301.29032855,
+      "price": 309.16636195,
       "hasErrors": false,
       "nbDays": 28,
       "consoHC": 513571.5,
-      "priceHC": 73.38621615,
+      "priceHC": 75.16352385,
       "consoHP": 940811.5,
-      "priceHP": 183.1741124
+      "priceHP": 188.1828381
     },
     {
       "year": 2025,
       "month": "01",
       "conso": 1656215,
-      "price": 567.8092991,
+      "price": 584.8488099,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 579563,
-      "priceHC": 85.5379871,
+      "priceHC": 87.6452821,
       "consoHP": 1076652,
-      "priceHP": 437.541312
+      "priceHP": 451.3835278
     },
     {
       "year": 2024,
       "month": "12",
       "conso": 1607614,
-      "price": 448.7850026,
+      "price": 461.6730658,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 566798,
-      "priceHC": 81.7199398,
+      "priceHC": 83.7108222,
       "consoHP": 1040816,
-      "priceHP": 322.3350628
+      "priceHP": 332.1422436
     },
     {
       "year": 2024,
       "month": "11",
       "conso": 1555490,
-      "price": 286.900003,
+      "price": 294.148225,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 546890,
-      "priceHC": 74.353696,
+      "priceHC": 76.114254,
       "consoHP": 1008600,
-      "priceHP": 167.816307
+      "priceHP": 172.213971
     },
     {
       "year": 2024,
       "month": "10",
       "conso": 801811,
-      "price": 166.8527097,
+      "price": 171.0370704,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 248405,
-      "priceHC": 32.9136625,
+      "priceHC": 33.683718,
       "consoHP": 553406,
-      "priceHP": 89.2090472
+      "priceHP": 91.5333524
     },
     {
       "year": 2024,
       "month": "09",
       "conso": 799403,
-      "price": 166.53030615,
+      "price": 170.7070739,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246113.5,
-      "priceHC": 32.61003875,
+      "priceHC": 33.3729906,
       "consoHP": 553289.5,
-      "priceHP": 89.1902674
+      "priceHP": 91.5140833
     },
     {
       "year": 2024,
       "month": "08",
       "conso": 828472,
-      "price": 170.8692029,
+      "price": 175.1547598,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 258205,
-      "priceHC": 34.2121625,
+      "priceHC": 35.012598,
       "consoHP": 570267,
-      "priceHP": 91.9270404
+      "priceHP": 94.3221618
     },
     {
       "year": 2024,
       "month": "07",
       "conso": 825926,
-      "price": 170.5990446,
+      "price": 174.879284,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 253318,
-      "priceHC": 33.564635,
+      "priceHC": 34.3499208,
       "consoHP": 572608,
-      "priceHP": 92.3044096
+      "priceHP": 94.7093632
     },
     {
       "year": 2024,
       "month": "06",
       "conso": 800346,
-      "price": 166.6781706,
+      "price": 170.85874,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246258,
-      "priceHC": 32.629185,
+      "priceHC": 33.3925848,
       "consoHP": 554088,
-      "priceHP": 89.3189856
+      "priceHP": 91.6461552
     },
     {
       "year": 2024,
       "month": "05",
       "conso": 825106,
-      "price": 170.4440728,
+      "price": 174.7199948,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 254112,
-      "priceHC": 33.66984,
+      "priceHC": 34.4575872,
       "consoHP": 570994,
-      "priceHP": 92.0442328
+      "priceHP": 94.4424076
     },
     {
       "year": 2024,
       "month": "04",
       "conso": 800686,
-      "price": 171.0652591,
+      "price": 175.3846594,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246406,
-      "priceHC": 33.6555155,
+      "priceHC": 34.4540886,
       "consoHP": 554280,
-      "priceHP": 92.6797436
+      "priceHP": 95.1105708
     },
     {
       "year": 2024,
       "month": "03",
       "conso": 1654175,
-      "price": 413.1575046,
+      "price": 424.7368095,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 577614,
-      "priceHC": 80.7821691,
+      "priceHC": 82.72342335,
       "consoHP": 1076561,
-      "priceHP": 287.6453355
+      "priceHP": 296.19338615
     },
     {
       "year": 2024,
       "month": "02",
       "conso": 1506524.5,
-      "price": 340.9696414,
+      "price": 350.19248315,
       "hasErrors": false,
       "nbDays": 29,
       "consoHC": 528451,
-      "priceHC": 74.5755868,
+      "priceHC": 76.37296865,
       "consoHP": 978073.5,
-      "priceHP": 221.6640546
+      "priceHP": 227.9995145
     }
   ],
   "EDF - Vert Electrique": [

--- a/tests/golden/monthly-36.json
+++ b/tests/golden/monthly-36.json
@@ -584,289 +584,289 @@
       "year": 2026,
       "month": "01",
       "conso": 1559396,
-      "price": 414.250546,
+      "price": 425.96216685,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 548544,
-      "priceHC": 79.2461712,
+      "priceHC": 81.17768685,
       "consoHP": 1010852,
-      "priceHP": 282.5843748
+      "priceHP": 291.02448
     },
     {
       "year": 2025,
       "month": "12",
       "conso": 1608788,
-      "price": 344.5909807,
+      "price": 353.76181555,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 564622,
-      "priceHC": 78.5682721,
+      "priceHC": 80.44898315,
       "consoHP": 1044166,
-      "priceHP": 213.6027086
+      "priceHP": 219.5528324
     },
     {
       "year": 2025,
       "month": "11",
       "conso": 1559840,
-      "price": 292.8662608,
+      "price": 300.3050812,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 549592,
-      "priceHC": 74.1018236,
+      "priceHC": 75.8497272,
       "consoHP": 1010248,
-      "priceHP": 166.3444372
+      "priceHP": 170.695354
     },
     {
       "year": 2025,
       "month": "10",
       "conso": 799746,
-      "price": 174.2743493,
+      "price": 178.7025098,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 246157,
-      "priceHC": 32.6158025,
+      "priceHC": 33.3788892,
       "consoHP": 553589,
-      "priceHP": 89.2385468
+      "priceHP": 91.5636206
     },
     {
       "year": 2025,
       "month": "09",
       "conso": 799807,
-      "price": 174.27148275,
+      "price": 178.6994127,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246599.5,
-      "priceHC": 32.67443375,
+      "priceHC": 33.4388922,
       "consoHP": 553207.5,
-      "priceHP": 89.177049
+      "priceHP": 91.5005205
     },
     {
       "year": 2025,
       "month": "08",
       "conso": 827880,
-      "price": 178.4929317,
+      "price": 183.0271198,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 257189,
-      "priceHC": 34.0775425,
+      "priceHC": 34.8748284,
       "consoHP": 570691,
-      "priceHP": 91.9953892
+      "priceHP": 94.3922914
     },
     {
       "year": 2025,
       "month": "07",
       "conso": 828294,
-      "price": 178.5782374,
+      "price": 183.114876,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256542,
-      "priceHC": 33.991815,
+      "priceHC": 34.7870952,
       "consoHP": 571752,
-      "priceHP": 92.1664224
+      "priceHP": 94.5677808
     },
     {
       "year": 2025,
       "month": "06",
       "conso": 801096,
-      "price": 174.3971158,
+      "price": 178.8273108,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249462,
-      "priceHC": 33.053715,
+      "priceHC": 33.8270472,
       "consoHP": 551634,
-      "priceHP": 88.9234008
+      "priceHP": 91.2402636
     },
     {
       "year": 2025,
       "month": "05",
       "conso": 828322,
-      "price": 178.575863,
+      "price": 183.1123552,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256782,
-      "priceHC": 34.023615,
+      "priceHC": 34.8196392,
       "consoHP": 571540,
-      "priceHP": 92.132248
+      "priceHP": 94.532716
     },
     {
       "year": 2025,
       "month": "04",
       "conso": 801142,
-      "price": 174.4002834,
+      "price": 178.8305088,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249610,
-      "priceHC": 33.073325,
+      "priceHC": 33.847116,
       "consoHP": 551532,
-      "priceHP": 88.9069584
+      "priceHP": 91.2233928
     },
     {
       "year": 2025,
       "month": "03",
       "conso": 1603692.5,
-      "price": 299.8228702,
+      "price": 307.4408927,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 560133,
-      "priceHC": 75.7056096,
+      "priceHC": 77.4933318,
       "consoHP": 1043559.5,
-      "priceHP": 171.6972606
+      "priceHP": 176.1875609
     },
     {
       "year": 2025,
       "month": "02",
       "conso": 1454383,
-      "price": 308.98032855,
+      "price": 317.10636195,
       "hasErrors": false,
       "nbDays": 28,
       "consoHC": 513571.5,
-      "priceHC": 73.38621615,
+      "priceHC": 75.16352385,
       "consoHP": 940811.5,
-      "priceHP": 183.1741124
+      "priceHP": 188.1828381
     },
     {
       "year": 2025,
       "month": "01",
       "conso": 1656215,
-      "price": 575.4992991,
+      "price": 592.7888099,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 579563,
-      "priceHC": 85.5379871,
+      "priceHC": 87.6452821,
       "consoHP": 1076652,
-      "priceHP": 437.541312
+      "priceHP": 451.3835278
     },
     {
       "year": 2024,
       "month": "12",
       "conso": 1607614,
-      "price": 456.4750026,
+      "price": 469.6130658,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 566798,
-      "priceHC": 81.7199398,
+      "priceHC": 83.7108222,
       "consoHP": 1040816,
-      "priceHP": 322.3350628
+      "priceHP": 332.1422436
     },
     {
       "year": 2024,
       "month": "11",
       "conso": 1555490,
-      "price": 294.590003,
+      "price": 302.088225,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 546890,
-      "priceHC": 74.353696,
+      "priceHC": 76.114254,
       "consoHP": 1008600,
-      "priceHP": 167.816307
+      "priceHP": 172.213971
     },
     {
       "year": 2024,
       "month": "10",
       "conso": 801811,
-      "price": 174.5427097,
+      "price": 178.9770704,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 248405,
-      "priceHC": 32.9136625,
+      "priceHC": 33.683718,
       "consoHP": 553406,
-      "priceHP": 89.2090472
+      "priceHP": 91.5333524
     },
     {
       "year": 2024,
       "month": "09",
       "conso": 799403,
-      "price": 174.22030615,
+      "price": 178.6470739,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246113.5,
-      "priceHC": 32.61003875,
+      "priceHC": 33.3729906,
       "consoHP": 553289.5,
-      "priceHP": 89.1902674
+      "priceHP": 91.5140833
     },
     {
       "year": 2024,
       "month": "08",
       "conso": 828472,
-      "price": 178.5592029,
+      "price": 183.0947598,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 258205,
-      "priceHC": 34.2121625,
+      "priceHC": 35.012598,
       "consoHP": 570267,
-      "priceHP": 91.9270404
+      "priceHP": 94.3221618
     },
     {
       "year": 2024,
       "month": "07",
       "conso": 825926,
-      "price": 178.2890446,
+      "price": 182.819284,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 253318,
-      "priceHC": 33.564635,
+      "priceHC": 34.3499208,
       "consoHP": 572608,
-      "priceHP": 92.3044096
+      "priceHP": 94.7093632
     },
     {
       "year": 2024,
       "month": "06",
       "conso": 800346,
-      "price": 174.3681706,
+      "price": 178.79874,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246258,
-      "priceHC": 32.629185,
+      "priceHC": 33.3925848,
       "consoHP": 554088,
-      "priceHP": 89.3189856
+      "priceHP": 91.6461552
     },
     {
       "year": 2024,
       "month": "05",
       "conso": 825106,
-      "price": 178.1340728,
+      "price": 182.6599948,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 254112,
-      "priceHC": 33.66984,
+      "priceHC": 34.4575872,
       "consoHP": 570994,
-      "priceHP": 92.0442328
+      "priceHP": 94.4424076
     },
     {
       "year": 2024,
       "month": "04",
       "conso": 800686,
-      "price": 178.7552591,
+      "price": 183.3246594,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246406,
-      "priceHC": 33.6555155,
+      "priceHC": 34.4540886,
       "consoHP": 554280,
-      "priceHP": 92.6797436
+      "priceHP": 95.1105708
     },
     {
       "year": 2024,
       "month": "03",
       "conso": 1654175,
-      "price": 420.8475046,
+      "price": 432.6768095,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 577614,
-      "priceHC": 80.7821691,
+      "priceHC": 82.72342335,
       "consoHP": 1076561,
-      "priceHP": 287.6453355
+      "priceHP": 296.19338615
     },
     {
       "year": 2024,
       "month": "02",
       "conso": 1506524.5,
-      "price": 348.6596414,
+      "price": 358.13248315,
       "hasErrors": false,
       "nbDays": 29,
       "consoHC": 528451,
-      "priceHC": 74.5755868,
+      "priceHC": 76.37296865,
       "consoHP": 978073.5,
-      "priceHP": 221.6640546
+      "priceHP": 227.9995145
     }
   ],
   "EDF - EJP": [

--- a/tests/golden/monthly-6.json
+++ b/tests/golden/monthly-6.json
@@ -584,289 +584,289 @@
       "year": 2026,
       "month": "01",
       "conso": 1559396,
-      "price": 377.420546,
+      "price": 388.00216685,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 548544,
-      "priceHC": 79.2461712,
+      "priceHC": 81.17768685,
       "consoHP": 1010852,
-      "priceHP": 282.5843748
+      "priceHP": 291.02448
     },
     {
       "year": 2025,
       "month": "12",
       "conso": 1608788,
-      "price": 307.7609807,
+      "price": 315.80181555,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 564622,
-      "priceHC": 78.5682721,
+      "priceHC": 80.44898315,
       "consoHP": 1044166,
-      "priceHP": 213.6027086
+      "priceHP": 219.5528324
     },
     {
       "year": 2025,
       "month": "11",
       "conso": 1559840,
-      "price": 256.0362608,
+      "price": 262.3450812,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 549592,
-      "priceHC": 74.1018236,
+      "priceHC": 75.8497272,
       "consoHP": 1010248,
-      "priceHP": 166.3444372
+      "priceHP": 170.695354
     },
     {
       "year": 2025,
       "month": "10",
       "conso": 799746,
-      "price": 137.4443493,
+      "price": 140.7425098,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 246157,
-      "priceHC": 32.6158025,
+      "priceHC": 33.3788892,
       "consoHP": 553589,
-      "priceHP": 89.2385468
+      "priceHP": 91.5636206
     },
     {
       "year": 2025,
       "month": "09",
       "conso": 799807,
-      "price": 137.44148275,
+      "price": 140.7394127,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246599.5,
-      "priceHC": 32.67443375,
+      "priceHC": 33.4388922,
       "consoHP": 553207.5,
-      "priceHP": 89.177049
+      "priceHP": 91.5005205
     },
     {
       "year": 2025,
       "month": "08",
       "conso": 827880,
-      "price": 141.6629317,
+      "price": 145.0671198,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 257189,
-      "priceHC": 34.0775425,
+      "priceHC": 34.8748284,
       "consoHP": 570691,
-      "priceHP": 91.9953892
+      "priceHP": 94.3922914
     },
     {
       "year": 2025,
       "month": "07",
       "conso": 828294,
-      "price": 141.7482374,
+      "price": 145.154876,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256542,
-      "priceHC": 33.991815,
+      "priceHC": 34.7870952,
       "consoHP": 571752,
-      "priceHP": 92.1664224
+      "priceHP": 94.5677808
     },
     {
       "year": 2025,
       "month": "06",
       "conso": 801096,
-      "price": 137.5671158,
+      "price": 140.8673108,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249462,
-      "priceHC": 33.053715,
+      "priceHC": 33.8270472,
       "consoHP": 551634,
-      "priceHP": 88.9234008
+      "priceHP": 91.2402636
     },
     {
       "year": 2025,
       "month": "05",
       "conso": 828322,
-      "price": 141.745863,
+      "price": 145.1523552,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256782,
-      "priceHC": 34.023615,
+      "priceHC": 34.8196392,
       "consoHP": 571540,
-      "priceHP": 92.132248
+      "priceHP": 94.532716
     },
     {
       "year": 2025,
       "month": "04",
       "conso": 801142,
-      "price": 137.5702834,
+      "price": 140.8705088,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249610,
-      "priceHC": 33.073325,
+      "priceHC": 33.847116,
       "consoHP": 551532,
-      "priceHP": 88.9069584
+      "priceHP": 91.2233928
     },
     {
       "year": 2025,
       "month": "03",
       "conso": 1603692.5,
-      "price": 262.9928702,
+      "price": 269.4808927,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 560133,
-      "priceHC": 75.7056096,
+      "priceHC": 77.4933318,
       "consoHP": 1043559.5,
-      "priceHP": 171.6972606
+      "priceHP": 176.1875609
     },
     {
       "year": 2025,
       "month": "02",
       "conso": 1454383,
-      "price": 272.15032855,
+      "price": 279.14636195,
       "hasErrors": false,
       "nbDays": 28,
       "consoHC": 513571.5,
-      "priceHC": 73.38621615,
+      "priceHC": 75.16352385,
       "consoHP": 940811.5,
-      "priceHP": 183.1741124
+      "priceHP": 188.1828381
     },
     {
       "year": 2025,
       "month": "01",
       "conso": 1656215,
-      "price": 538.6692991,
+      "price": 554.8288099,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 579563,
-      "priceHC": 85.5379871,
+      "priceHC": 87.6452821,
       "consoHP": 1076652,
-      "priceHP": 437.541312
+      "priceHP": 451.3835278
     },
     {
       "year": 2024,
       "month": "12",
       "conso": 1607614,
-      "price": 419.6450026,
+      "price": 431.6530658,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 566798,
-      "priceHC": 81.7199398,
+      "priceHC": 83.7108222,
       "consoHP": 1040816,
-      "priceHP": 322.3350628
+      "priceHP": 332.1422436
     },
     {
       "year": 2024,
       "month": "11",
       "conso": 1555490,
-      "price": 257.760003,
+      "price": 264.128225,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 546890,
-      "priceHC": 74.353696,
+      "priceHC": 76.114254,
       "consoHP": 1008600,
-      "priceHP": 167.816307
+      "priceHP": 172.213971
     },
     {
       "year": 2024,
       "month": "10",
       "conso": 801811,
-      "price": 137.7127097,
+      "price": 141.0170704,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 248405,
-      "priceHC": 32.9136625,
+      "priceHC": 33.683718,
       "consoHP": 553406,
-      "priceHP": 89.2090472
+      "priceHP": 91.5333524
     },
     {
       "year": 2024,
       "month": "09",
       "conso": 799403,
-      "price": 137.39030615,
+      "price": 140.6870739,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246113.5,
-      "priceHC": 32.61003875,
+      "priceHC": 33.3729906,
       "consoHP": 553289.5,
-      "priceHP": 89.1902674
+      "priceHP": 91.5140833
     },
     {
       "year": 2024,
       "month": "08",
       "conso": 828472,
-      "price": 141.7292029,
+      "price": 145.1347598,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 258205,
-      "priceHC": 34.2121625,
+      "priceHC": 35.012598,
       "consoHP": 570267,
-      "priceHP": 91.9270404
+      "priceHP": 94.3221618
     },
     {
       "year": 2024,
       "month": "07",
       "conso": 825926,
-      "price": 141.4590446,
+      "price": 144.859284,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 253318,
-      "priceHC": 33.564635,
+      "priceHC": 34.3499208,
       "consoHP": 572608,
-      "priceHP": 92.3044096
+      "priceHP": 94.7093632
     },
     {
       "year": 2024,
       "month": "06",
       "conso": 800346,
-      "price": 137.5381706,
+      "price": 140.83874,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246258,
-      "priceHC": 32.629185,
+      "priceHC": 33.3925848,
       "consoHP": 554088,
-      "priceHP": 89.3189856
+      "priceHP": 91.6461552
     },
     {
       "year": 2024,
       "month": "05",
       "conso": 825106,
-      "price": 141.3040728,
+      "price": 144.6999948,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 254112,
-      "priceHC": 33.66984,
+      "priceHC": 34.4575872,
       "consoHP": 570994,
-      "priceHP": 92.0442328
+      "priceHP": 94.4424076
     },
     {
       "year": 2024,
       "month": "04",
       "conso": 800686,
-      "price": 141.9252591,
+      "price": 145.3646594,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246406,
-      "priceHC": 33.6555155,
+      "priceHC": 34.4540886,
       "consoHP": 554280,
-      "priceHP": 92.6797436
+      "priceHP": 95.1105708
     },
     {
       "year": 2024,
       "month": "03",
       "conso": 1654175,
-      "price": 384.0175046,
+      "price": 394.7168095,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 577614,
-      "priceHC": 80.7821691,
+      "priceHC": 82.72342335,
       "consoHP": 1076561,
-      "priceHP": 287.6453355
+      "priceHP": 296.19338615
     },
     {
       "year": 2024,
       "month": "02",
       "conso": 1506524.5,
-      "price": 311.8296414,
+      "price": 320.17248315,
       "hasErrors": false,
       "nbDays": 29,
       "consoHC": 528451,
-      "priceHC": 74.5755868,
+      "priceHC": 76.37296865,
       "consoHP": 978073.5,
-      "priceHP": 221.6640546
+      "priceHP": 227.9995145
     }
   ],
   "EDF - Vert Electrique": [

--- a/tests/golden/monthly-9.json
+++ b/tests/golden/monthly-9.json
@@ -584,289 +584,289 @@
       "year": 2026,
       "month": "01",
       "conso": 1559396,
-      "price": 381.210546,
+      "price": 391.90216685,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 548544,
-      "priceHC": 79.2461712,
+      "priceHC": 81.17768685,
       "consoHP": 1010852,
-      "priceHP": 282.5843748
+      "priceHP": 291.02448
     },
     {
       "year": 2025,
       "month": "12",
       "conso": 1608788,
-      "price": 311.5509807,
+      "price": 319.70181555,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 564622,
-      "priceHC": 78.5682721,
+      "priceHC": 80.44898315,
       "consoHP": 1044166,
-      "priceHP": 213.6027086
+      "priceHP": 219.5528324
     },
     {
       "year": 2025,
       "month": "11",
       "conso": 1559840,
-      "price": 259.8262608,
+      "price": 266.2450812,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 549592,
-      "priceHC": 74.1018236,
+      "priceHC": 75.8497272,
       "consoHP": 1010248,
-      "priceHP": 166.3444372
+      "priceHP": 170.695354
     },
     {
       "year": 2025,
       "month": "10",
       "conso": 799746,
-      "price": 141.2343493,
+      "price": 144.6425098,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 246157,
-      "priceHC": 32.6158025,
+      "priceHC": 33.3788892,
       "consoHP": 553589,
-      "priceHP": 89.2385468
+      "priceHP": 91.5636206
     },
     {
       "year": 2025,
       "month": "09",
       "conso": 799807,
-      "price": 141.23148275,
+      "price": 144.6394127,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246599.5,
-      "priceHC": 32.67443375,
+      "priceHC": 33.4388922,
       "consoHP": 553207.5,
-      "priceHP": 89.177049
+      "priceHP": 91.5005205
     },
     {
       "year": 2025,
       "month": "08",
       "conso": 827880,
-      "price": 145.4529317,
+      "price": 148.9671198,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 257189,
-      "priceHC": 34.0775425,
+      "priceHC": 34.8748284,
       "consoHP": 570691,
-      "priceHP": 91.9953892
+      "priceHP": 94.3922914
     },
     {
       "year": 2025,
       "month": "07",
       "conso": 828294,
-      "price": 145.5382374,
+      "price": 149.054876,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256542,
-      "priceHC": 33.991815,
+      "priceHC": 34.7870952,
       "consoHP": 571752,
-      "priceHP": 92.1664224
+      "priceHP": 94.5677808
     },
     {
       "year": 2025,
       "month": "06",
       "conso": 801096,
-      "price": 141.3571158,
+      "price": 144.7673108,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249462,
-      "priceHC": 33.053715,
+      "priceHC": 33.8270472,
       "consoHP": 551634,
-      "priceHP": 88.9234008
+      "priceHP": 91.2402636
     },
     {
       "year": 2025,
       "month": "05",
       "conso": 828322,
-      "price": 145.535863,
+      "price": 149.0523552,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 256782,
-      "priceHC": 34.023615,
+      "priceHC": 34.8196392,
       "consoHP": 571540,
-      "priceHP": 92.132248
+      "priceHP": 94.532716
     },
     {
       "year": 2025,
       "month": "04",
       "conso": 801142,
-      "price": 141.3602834,
+      "price": 144.7705088,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 249610,
-      "priceHC": 33.073325,
+      "priceHC": 33.847116,
       "consoHP": 551532,
-      "priceHP": 88.9069584
+      "priceHP": 91.2233928
     },
     {
       "year": 2025,
       "month": "03",
       "conso": 1603692.5,
-      "price": 266.7828702,
+      "price": 273.3808927,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 560133,
-      "priceHC": 75.7056096,
+      "priceHC": 77.4933318,
       "consoHP": 1043559.5,
-      "priceHP": 171.6972606
+      "priceHP": 176.1875609
     },
     {
       "year": 2025,
       "month": "02",
       "conso": 1454383,
-      "price": 275.94032855,
+      "price": 283.04636195,
       "hasErrors": false,
       "nbDays": 28,
       "consoHC": 513571.5,
-      "priceHC": 73.38621615,
+      "priceHC": 75.16352385,
       "consoHP": 940811.5,
-      "priceHP": 183.1741124
+      "priceHP": 188.1828381
     },
     {
       "year": 2025,
       "month": "01",
       "conso": 1656215,
-      "price": 542.4592991,
+      "price": 558.7288099,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 579563,
-      "priceHC": 85.5379871,
+      "priceHC": 87.6452821,
       "consoHP": 1076652,
-      "priceHP": 437.541312
+      "priceHP": 451.3835278
     },
     {
       "year": 2024,
       "month": "12",
       "conso": 1607614,
-      "price": 423.4350026,
+      "price": 435.5530658,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 566798,
-      "priceHC": 81.7199398,
+      "priceHC": 83.7108222,
       "consoHP": 1040816,
-      "priceHP": 322.3350628
+      "priceHP": 332.1422436
     },
     {
       "year": 2024,
       "month": "11",
       "conso": 1555490,
-      "price": 261.550003,
+      "price": 268.028225,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 546890,
-      "priceHC": 74.353696,
+      "priceHC": 76.114254,
       "consoHP": 1008600,
-      "priceHP": 167.816307
+      "priceHP": 172.213971
     },
     {
       "year": 2024,
       "month": "10",
       "conso": 801811,
-      "price": 141.5027097,
+      "price": 144.9170704,
       "hasErrors": true,
       "nbDays": 30,
       "consoHC": 248405,
-      "priceHC": 32.9136625,
+      "priceHC": 33.683718,
       "consoHP": 553406,
-      "priceHP": 89.2090472
+      "priceHP": 91.5333524
     },
     {
       "year": 2024,
       "month": "09",
       "conso": 799403,
-      "price": 141.18030615,
+      "price": 144.5870739,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246113.5,
-      "priceHC": 32.61003875,
+      "priceHC": 33.3729906,
       "consoHP": 553289.5,
-      "priceHP": 89.1902674
+      "priceHP": 91.5140833
     },
     {
       "year": 2024,
       "month": "08",
       "conso": 828472,
-      "price": 145.5192029,
+      "price": 149.0347598,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 258205,
-      "priceHC": 34.2121625,
+      "priceHC": 35.012598,
       "consoHP": 570267,
-      "priceHP": 91.9270404
+      "priceHP": 94.3221618
     },
     {
       "year": 2024,
       "month": "07",
       "conso": 825926,
-      "price": 145.2490446,
+      "price": 148.759284,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 253318,
-      "priceHC": 33.564635,
+      "priceHC": 34.3499208,
       "consoHP": 572608,
-      "priceHP": 92.3044096
+      "priceHP": 94.7093632
     },
     {
       "year": 2024,
       "month": "06",
       "conso": 800346,
-      "price": 141.3281706,
+      "price": 144.73874,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246258,
-      "priceHC": 32.629185,
+      "priceHC": 33.3925848,
       "consoHP": 554088,
-      "priceHP": 89.3189856
+      "priceHP": 91.6461552
     },
     {
       "year": 2024,
       "month": "05",
       "conso": 825106,
-      "price": 145.0940728,
+      "price": 148.5999948,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 254112,
-      "priceHC": 33.66984,
+      "priceHC": 34.4575872,
       "consoHP": 570994,
-      "priceHP": 92.0442328
+      "priceHP": 94.4424076
     },
     {
       "year": 2024,
       "month": "04",
       "conso": 800686,
-      "price": 145.7152591,
+      "price": 149.2646594,
       "hasErrors": false,
       "nbDays": 30,
       "consoHC": 246406,
-      "priceHC": 33.6555155,
+      "priceHC": 34.4540886,
       "consoHP": 554280,
-      "priceHP": 92.6797436
+      "priceHP": 95.1105708
     },
     {
       "year": 2024,
       "month": "03",
       "conso": 1654175,
-      "price": 387.8075046,
+      "price": 398.6168095,
       "hasErrors": false,
       "nbDays": 31,
       "consoHC": 577614,
-      "priceHC": 80.7821691,
+      "priceHC": 82.72342335,
       "consoHP": 1076561,
-      "priceHP": 287.6453355
+      "priceHP": 296.19338615
     },
     {
       "year": 2024,
       "month": "02",
       "conso": 1506524.5,
-      "price": 315.6196414,
+      "price": 324.07248315,
       "hasErrors": false,
       "nbDays": 29,
       "consoHC": 528451,
-      "priceHC": 74.5755868,
+      "priceHC": 76.37296865,
       "consoHP": 978073.5,
-      "priceHP": 221.6640546
+      "priceHP": 227.9995145
     }
   ],
   "EDF - EJP": [


### PR DESCRIPTION
Aligne les tarifs Tempo sur la grille EDF en vigueur depuis le 1er août 2026, parsée directement depuis le PDF officiel via `import/update.mjs`.

## Test plan

- [x] `node import/update.mjs --tarif "EDF - Tempo"`
- [x] `UPDATE_GOLDEN=1 node --test "tests/**/*.test.mjs"` : 116/116