### PR TITLE
Corrige l'ordre des relevés du graphe horaire

### DIFF
--- a/scripts/core/calculator.js
+++ b/scripts/core/calculator.js
@@ -96,7 +96,11 @@ function computeDay(day, aboPriceByDay, plan, getDayType, hcRangesFor, spotPrice
         return dayData;
     }
 
-    for (const [timeLabel, rawValue] of day.hours) {
+    // L'export EDF liste les relevés du plus récent au plus ancien : on trie
+    // avant construction, l'ordre de dayData.hours portant le graphe horaire.
+    const sortedHours = [...day.hours].sort((a, b) => a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
+
+    for (const [timeLabel, rawValue] of sortedHours) {
         const [hour, minute] = timeLabel.split(":");
         const hourData = {
             time: { hour: parseInt(hour), minute: parseInt(minute) },

--- a/tests/unit/calculator.test.mjs
+++ b/tests/unit/calculator.test.mjs
@@ -49,6 +49,19 @@ test('formule de prix : W / step -> kWh, centimes -> euros, abonnement réparti 
     assert.ok(Math.abs(day.price - (2.4 + 30 / 31)) < 1e-9);
 });
 
+test('relevés fournis dans le désordre (export EDF : du plus récent au plus ancien) -> hours triées chronologiquement', () => {
+    const grille = makeGrille();
+    const day = makeFullDay('2024/03/05');
+    day.hours = [...day.hours].reverse();
+    const months = computeMonths(viewOf(grille), [day]);
+
+    const labels = months[0].days[0].hours.map(h =>
+        `${String(h.time.hour).padStart(2, '0')}:${String(h.time.minute).padStart(2, '0')}`);
+    assert.deepStrictEqual(labels, [...labels].sort());
+    assert.strictEqual(labels[0], '00:30');
+    assert.strictEqual(labels[labels.length - 1], '24:00');
+});
+
 test('jour incomplet (moins de 24 relevés) : conso et prix NaN', () => {
     const grille = makeGrille();
     const months = computeMonths(viewOf(grille), [makePartialDay('2024/03/05', 10)]);


### PR DESCRIPTION
Les exports EDF (\"mes-puissances-atteintes-30min\") listent les relevés du plus récent au plus ancien. `computeDay` construisait `dayData.hours` dans cet ordre sans le trier, alors que le graphe horaire (`dayChart.js`) positionne chaque barre par index en supposant un ordre chronologique croissant. Résultat : les couleurs HP/HC affichées ne correspondaient pas aux heures indiquées sur l'axe.

Tri chronologique ajouté dans `computeDay`, seul point de passage commun à tous les parsers.

## Test plan

- [x] `node --test tests/unit/calculator.test.mjs tests/unit/dayChart.test.mjs`
- [x] Vérification visuelle : graphe horaire d'un tarif HP/HC, couleurs alignées sur les plages configurées